### PR TITLE
Added command to list all mods

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/packwiz/packwiz/core"
+	"github.com/spf13/cobra"
+)
+
+// listCmd represents the list command
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all the mods in the modpack",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		// Load pack
+		pack, err := core.LoadPack()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		// Load index
+		index, err := pack.LoadIndex()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		// Load mods
+		mods, err := index.LoadAllMods()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		// Print mods
+		for _, mod := range mods {
+			fmt.Println(mod.Name)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+}


### PR DESCRIPTION
Implemented `packwiz list` command to list all mods in the current modpack. Fairly basic implementation currently, but should be enough to close #48 and is a little more clean than #67 .