### PR TITLE
Controlling the cache directory

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,6 +55,14 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&metaFolderBase, "meta-folder-base", ".", "The base folder from which meta-folder will be resolved, defaulting to the current directory (so you can put all mods/etc in a subfolder while still using the default behaviour)")
 	_ = viper.BindPFlag("meta-folder-base", rootCmd.PersistentFlags().Lookup("meta-folder-base"))
 
+	defaultCacheDir, err := core.GetPackwizCache()
+	cacheUsage := "The directory where packwiz will cache downloaded mods"
+	if err == nil {
+		cacheUsage += "(default \""+defaultCacheDir+"\")"
+	}
+	rootCmd.PersistentFlags().String("cache", defaultCacheDir, cacheUsage)
+	_ = viper.BindPFlag("cache.directory", rootCmd.PersistentFlags().Lookup("cache"))
+
 	file, err := core.GetPackwizLocalStore()
 	if err != nil {
 		fmt.Println(err)

--- a/core/storeutil.go
+++ b/core/storeutil.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+
+	"github.com/spf13/viper"
 )
 
 func GetPackwizLocalStore() (string, error) {
@@ -54,6 +56,10 @@ func GetPackwizInstallBinFile() (string, error) {
 }
 
 func GetPackwizCache() (string, error) {
+	configuredCache := viper.GetString("cache.directory")
+	if configuredCache != "" {
+		return configuredCache, nil
+	}
 	localStore, err := GetPackwizLocalCache()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This Adds a `--cache` option to the root command, bound to the viper config `"cache.directory"` entry, defaulting to the old `core.GetPackwizCache()` behavior. It solves #129.
