### PR TITLE
Add index page to the development server

### DIFF
--- a/cmd/serve-templates/index.html
+++ b/cmd/serve-templates/index.html
@@ -31,7 +31,7 @@
         It works! Packwiz development server is running!
     </h1>
     <p>
-        To install pack you'll need a <a href="https://packwiz.infra.link/tutorials/installing/packwiz-installer/" target="_blank">packwiz-installer</a>.
+        Use <a href="https://packwiz.infra.link/tutorials/installing/packwiz-installer/" target="_blank">packwiz-installer</a> to install the pack from this HTTP server - works best with MultiMC/PolyMC/ATLauncher, or standalone for servers.
     </p>
     <p>
         Your <code>pack.toml</code> is hosted at <code>http://localhost:{{.Port}}/pack.toml</code>.

--- a/cmd/serve-templates/index.html
+++ b/cmd/serve-templates/index.html
@@ -31,7 +31,7 @@
         It works! Packwiz development server is running!
     </h1>
     <p>
-        To install pack you'll need a <a href="https://packwiz.infra.link/tutorials/installing/packwiz-installer/">packwiz-installer</a>.
+        To install pack you'll need a <a href="https://packwiz.infra.link/tutorials/installing/packwiz-installer/" target="_blank">packwiz-installer</a>.
     </p>
     <p>
         Your <code>pack.toml</code> is hosted at <code>http://localhost:{{.Port}}/pack.toml</code>.

--- a/cmd/serve-templates/index.html
+++ b/cmd/serve-templates/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>packwiz development server</title>
+    <style>
+        h1, p {
+            text-align: center;
+            margin: 1.5em;
+            font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+        }
+        hr {
+            width: 100px;
+            height: 1px;
+            border: none;
+            background-color: #ccc;
+            color: #ccc;
+        }
+        code {
+            background-color: #f5f5f5;
+            border-radius: 2px;
+            padding: 1px 5px;
+            font-size: 0.85rem;
+        }
+    </style>
+</head>
+<body>
+    <h1>
+        It works! Packwiz development server is running!
+    </h1>
+    <p>
+        To install pack you'll need a <a href="https://packwiz.infra.link/tutorials/installing/packwiz-installer/">packwiz-installer</a>.
+    </p>
+    <p>
+        Your <code>pack.toml</code> is hosted at <code>http://localhost:{{.Port}}/pack.toml</code>.
+    </p>
+    <hr>
+    <p>
+        <a href="https://packwiz.infra.link" target="_blank">packwiz</a>
+    </p>
+</body>
+</html>


### PR DESCRIPTION
This adds an index (`/`) page to the development server. 

The index page contains link to the [Pack Installation using packwiz-installer](https://packwiz.infra.link/tutorials/installing/packwiz-installer/) page and the HTTP URL where `pack.toml` file is hosted (`http://localhost:{port}/pack.toml`).

![изображение](https://user-images.githubusercontent.com/36362599/183046779-9205dc62-4ecb-419e-9102-20621335627e.png)

It solves #124.