### PR TITLE
Add Curseforge's beta site to regex

### DIFF
--- a/curseforge/curseforge.go
+++ b/curseforge/curseforge.go
@@ -112,7 +112,7 @@ func getCurseforgeVersion(mcVersion string) string {
 
 var urlRegexes = [...]*regexp.Regexp{
 	regexp.MustCompile("^https?://(?P<game>minecraft)\\.curseforge\\.com/projects/(?P<slug>[^/]+)(?:/(?:files|download)/(?P<fileID>\\d+))?"),
-	regexp.MustCompile("^https?://(?:www\\.)?curseforge\\.com/(?P<game>[^/]+)/(?P<category>[^/]+)/(?P<slug>[^/]+)(?:/(?:files|download)/(?P<fileID>\\d+))?"),
+	regexp.MustCompile("^https?://(?:www\\.|beta\\.)?curseforge\\.com/(?P<game>[^/]+)/(?P<category>[^/]+)/(?P<slug>[^/]+)(?:/(?:files|download)/(?P<fileID>\\d+))?"),
 	regexp.MustCompile("^(?P<slug>[a-z][\\da-z\\-_]{0,127})$"),
 }
 


### PR DESCRIPTION
CurseForge currently has a beta site going on. It's much much better than their old one so I've been using it to search for new mods to add to my packs. This PR should add their beta subdomain to the `urlRegexes` slice and allow us to use the beta pages to install mods because right now it just uses the url to attempt a search.