### PR TITLE
Convert download hashes to lower before compare

### DIFF
--- a/core/download.go
+++ b/core/download.go
@@ -268,7 +268,7 @@ func teeHashes(hashesToObtain []string, hashes map[string]string,
 	calculatedHash := mainHasher.HashToString(mainHasher.Sum(nil))
 
 	// Check if the hash of the downloaded file matches the expected hash
-	if calculatedHash != validateHash {
+	if strings.ToLower(calculatedHash) != strings.ToLower(validateHash) {
 		return fmt.Errorf(
 			"%s hash of downloaded file does not match with expected hash!\n download hash: %s\n expected hash: %s\n",
 			validateHashFormat, calculatedHash, validateHash)


### PR DESCRIPTION
Currently if the hashes are in a different case an error will throw since they're not correct. Since the hashes are case insensitive, we're safe to convert them to lower before comparing. 