### PR TITLE
Add a command for changing the acceptable versions

### DIFF
--- a/curseforge/install.go
+++ b/curseforge/install.go
@@ -417,7 +417,7 @@ func getLatestFile(modInfoData modInfo, mcVersions []string, fileID uint32, pack
 
 		// Possible to reach this point without obtaining file info; particularly from GameVersionLatestFiles
 		if fileID == 0 {
-			return modFileInfo{}, errors.New("mod not available for the configured Minecraft version(s) (use the acceptable-game-versions option to accept more) or loader")
+			return modFileInfo{}, errors.New("mod not available for the configured Minecraft version(s) (use the 'packwiz settings acceptable-versions' command to accept more) or loader")
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"github.com/packwiz/packwiz/cmd"
 	_ "github.com/packwiz/packwiz/curseforge"
 	_ "github.com/packwiz/packwiz/modrinth"
+	_ "github.com/packwiz/packwiz/settings"
 	_ "github.com/packwiz/packwiz/url"
 	_ "github.com/packwiz/packwiz/utils"
 )

--- a/modrinth/install.go
+++ b/modrinth/install.go
@@ -205,7 +205,7 @@ func installProject(project *modrinthApi.Project, versionFilename string, pack c
 		return fmt.Errorf("failed to get latest version: %v", err)
 	}
 	if latestVersion.ID == nil {
-		return errors.New("mod not available for the configured Minecraft version(s) (use the acceptable-game-versions option to accept more) or loader")
+		return errors.New("mod not available for the configured Minecraft version(s) (use the 'packwiz settings acceptable-versions' command to accept more) or loader")
 	}
 
 	return installVersion(project, latestVersion, versionFilename, pack, index)

--- a/modrinth/modrinth.go
+++ b/modrinth/modrinth.go
@@ -287,7 +287,7 @@ func getLatestVersion(projectID string, name string, pack core.Pack) (*modrinthA
 	}
 	if len(result) == 0 {
 		// TODO: retry with datapack specified, to determine what the issue is? or just request all and filter afterwards
-		return nil, errors.New("no valid versions found\n\tUse the acceptable-game-versions option to accept more game versions\n\tTo use datapacks, add a datapack loader mod and specify the datapack-folder option with the folder this mod loads datapacks from")
+		return nil, errors.New("no valid versions found\n\tUse the 'packwiz settings acceptable-versions' command to accept more game versions\n\tTo use datapacks, add a datapack loader mod and specify the datapack-folder option with the folder this mod loads datapacks from")
 	}
 
 	// TODO: option to always compare using flexver?

--- a/settings/acceptable_versions.go
+++ b/settings/acceptable_versions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/packwiz/packwiz/core"
 	"github.com/spf13/cobra"
+	"golang.org/x/exp/slices"
 	"os"
 	"strings"
 )
@@ -26,14 +27,21 @@ var acceptableVersionsCommand = &cobra.Command{
 		}
 		acceptableVersions := args[0]
 		acceptableVersionsList := strings.Split(acceptableVersions, ",")
-		modpack.Options["acceptable-game-versions"] = acceptableVersionsList
+		// Dedupe the list
+		acceptableVersionsDeduped := []string(nil)
+		for i, v := range acceptableVersionsList {
+			if !slices.Contains(acceptableVersionsList[i+1:], v) {
+				acceptableVersionsDeduped = append(acceptableVersionsDeduped, v)
+			}
+		}
+		modpack.Options["acceptable-game-versions"] = acceptableVersionsDeduped
 		err = modpack.Write()
 		if err != nil {
 			fmt.Printf("Error writing pack: %s\n", err)
 			os.Exit(1)
 		}
 		// Print success message
-		prettyList := strings.Join(acceptableVersionsList, ", ")
+		prettyList := strings.Join(acceptableVersionsDeduped, ", ")
 		fmt.Printf("Set acceptable versions to %s\n", prettyList)
 	},
 }

--- a/settings/acceptable_versions.go
+++ b/settings/acceptable_versions.go
@@ -73,7 +73,8 @@ var acceptableVersionsCommand = &cobra.Command{
 				os.Exit(1)
 			}
 			// Remove the version from the list
-			currentVersions = slices.Delete(currentVersions, slices.Index(currentVersions, acceptableVersion), 1)
+			i := slices.Index(currentVersions, acceptableVersion)
+			currentVersions = slices.Delete(currentVersions, i, i+1)
 			// Sort it just in case it's out of order
 			flexver.VersionSlice(currentVersions).Sort()
 			// Set the new list

--- a/settings/acceptable_versions.go
+++ b/settings/acceptable_versions.go
@@ -1,0 +1,43 @@
+package settings
+
+import (
+	"fmt"
+	"github.com/packwiz/packwiz/core"
+	"github.com/spf13/cobra"
+	"os"
+	"strings"
+)
+
+var acceptableVersionsCommand = &cobra.Command{
+	Use:     "acceptable-versions",
+	Short:   "Manage your pack's acceptable versions. This must be a comma seperated list of Minecraft versions, e.g. 1.16.5,1.16.4,1.16.3",
+	Aliases: []string{"av"},
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		modpack, err := core.LoadPack()
+		if err != nil {
+			// Check if it's a no sucj fiole or directory error
+			if os.IsNotExist(err) {
+				fmt.Println("No pack.toml file found, run 'packwiz init' to create one!")
+				os.Exit(1)
+			}
+			fmt.Printf("Error loading pack: %s\n", err)
+			os.Exit(1)
+		}
+		acceptableVersions := args[0]
+		acceptableVersionsList := strings.Split(acceptableVersions, ",")
+		modpack.Options["acceptable-game-versions"] = acceptableVersionsList
+		err = modpack.Write()
+		if err != nil {
+			fmt.Printf("Error writing pack: %s\n", err)
+			os.Exit(1)
+		}
+		// Print success message
+		prettyList := strings.Join(acceptableVersionsList, ", ")
+		fmt.Printf("Set acceptable versions to %s\n", prettyList)
+	},
+}
+
+func init() {
+	settingsCmd.AddCommand(acceptableVersionsCommand)
+}

--- a/settings/acceptable_versions.go
+++ b/settings/acceptable_versions.go
@@ -29,9 +29,17 @@ var acceptableVersionsCommand = &cobra.Command{
 			os.Exit(1)
 		}
 		var currentVersions []string
-		// Convert the interface{} to a string slice
-		for _, v := range modpack.Options["acceptable-game-versions"].([]interface{}) {
-			currentVersions = append(currentVersions, v.(string))
+		// Check if they have no options whatsoever
+		if modpack.Options == nil {
+			// Initialize the options
+			modpack.Options = make(map[string]interface{})
+		}
+		// Check if the acceptable-game-versions is nil, which would mean their pack.toml doesn't have it set yet
+		if modpack.Options["acceptable-game-versions"] != nil {
+			// Convert the interface{} to a string slice
+			for _, v := range modpack.Options["acceptable-game-versions"].([]interface{}) {
+				currentVersions = append(currentVersions, v.(string))
+			}
 		}
 		// Check our flags to see if we're adding or removing
 		if viper.GetBool("settings.acceptable-versions.add") {

--- a/settings/acceptable_versions.go
+++ b/settings/acceptable_versions.go
@@ -17,7 +17,7 @@ var acceptableVersionsCommand = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		modpack, err := core.LoadPack()
 		if err != nil {
-			// Check if it's a no sucj fiole or directory error
+			// Check if it's a no such file or directory error
 			if os.IsNotExist(err) {
 				fmt.Println("No pack.toml file found, run 'packwiz init' to create one!")
 				os.Exit(1)

--- a/settings/acceptable_versions.go
+++ b/settings/acceptable_versions.go
@@ -5,6 +5,7 @@ import (
 	"github.com/packwiz/packwiz/cmdshared"
 	"github.com/packwiz/packwiz/core"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/unascribed/FlexVer/go/flexver"
 	"golang.org/x/exp/slices"
 	"os"
@@ -27,48 +28,116 @@ var acceptableVersionsCommand = &cobra.Command{
 			fmt.Printf("Error loading pack: %s\n", err)
 			os.Exit(1)
 		}
-		acceptableVersions := args[0]
-		acceptableVersionsList := strings.Split(acceptableVersions, ",")
-		// Dedupe the list
-		acceptableVersionsDeduped := []string(nil)
-		for i, v := range acceptableVersionsList {
-			if !slices.Contains(acceptableVersionsList[i+1:], v) {
-				acceptableVersionsDeduped = append(acceptableVersionsDeduped, v)
-			}
+		var currentVersions []string
+		// Convert the interface{} to a string slice
+		for _, v := range modpack.Options["acceptable-game-versions"].([]interface{}) {
+			currentVersions = append(currentVersions, v.(string))
 		}
-		// Check if the list of versions is out of order, lowest to highest, and inform the user if it is
-		// Compare the versions one by one to the next one, if the next one is lower, then it's out of order
-		for i, v := range acceptableVersionsDeduped {
-			if flexver.Less(acceptableVersionsDeduped[i+1], v) {
-				fmt.Printf("Warning: Your acceptable versions list is out of order. ")
-				// Give a do you mean example
-				// Clone the list
-				acceptableVersionsDedupedClone := make([]string, len(acceptableVersionsDeduped))
-				copy(acceptableVersionsDedupedClone, acceptableVersionsDeduped)
-				flexver.VersionSlice(acceptableVersionsDedupedClone).Sort()
-				fmt.Printf("Did you mean %s?\n", strings.Join(acceptableVersionsDedupedClone, ", "))
-				if cmdshared.PromptYesNo("Would you like to fix this automatically? [Y/n] ") {
-					// If yes we'll just set the list to the sorted one
-					acceptableVersionsDeduped = acceptableVersionsDedupedClone
-					break
-				} else {
-					// If no we'll just continue
+		// Check our flags to see if we're adding or removing
+		if viper.GetBool("settings.acceptable-versions.add") {
+			// Adding
+			acceptableVersion := args[0]
+			// Check if the version is already in the list
+			if slices.Contains(currentVersions, acceptableVersion) {
+				fmt.Printf("Version %s is already in your acceptable versions list!\n", acceptableVersion)
+				os.Exit(1)
+			}
+			// Add the version to the list and re-sort it
+			currentVersions = append(currentVersions, acceptableVersion)
+			flexver.VersionSlice(currentVersions).Sort()
+			// Set the new list
+			modpack.Options["acceptable-game-versions"] = currentVersions
+			// Save the pack
+			err = modpack.Write()
+			if err != nil {
+				fmt.Printf("Error writing pack: %s\n", err)
+				os.Exit(1)
+			}
+			// Print success message
+			prettyList := strings.Join(currentVersions, ", ")
+			fmt.Printf("Added %s to acceptable versions list, now %s\n", acceptableVersion, prettyList)
+		} else if viper.GetBool("settings.acceptable-versions.remove") {
+			// Removing
+			acceptableVersion := args[0]
+			// Check if the version is in the list
+			if !slices.Contains(currentVersions, acceptableVersion) {
+				fmt.Printf("Version %s is not in your acceptable versions list!\n", acceptableVersion)
+				os.Exit(1)
+			}
+			// Remove the version from the list
+			for i, v := range currentVersions {
+				if v == acceptableVersion {
+					currentVersions = append(currentVersions[:i], currentVersions[i+1:]...)
 					break
 				}
 			}
+			// Sort it just in case it's out of order
+			flexver.VersionSlice(currentVersions).Sort()
+			// Set the new list
+			modpack.Options["acceptable-game-versions"] = currentVersions
+			// Save the pack
+			err = modpack.Write()
+			if err != nil {
+				fmt.Printf("Error writing pack: %s\n", err)
+				os.Exit(1)
+			}
+			// Print success message
+			prettyList := strings.Join(currentVersions, ", ")
+			fmt.Printf("Removed %s from acceptable versions list, now %s\n", acceptableVersion, prettyList)
+		} else {
+			// Overwriting
+			acceptableVersions := args[0]
+			acceptableVersionsList := strings.Split(acceptableVersions, ",")
+			// Dedupe the list
+			acceptableVersionsDeduped := []string(nil)
+			for i, v := range acceptableVersionsList {
+				if !slices.Contains(acceptableVersionsList[i+1:], v) {
+					acceptableVersionsDeduped = append(acceptableVersionsDeduped, v)
+				}
+			}
+			// Check if the list of versions is out of order, lowest to highest, and inform the user if it is
+			// Compare the versions one by one to the next one, if the next one is lower, then it's out of order
+			// If it's only 1 element long, then it's already sorted
+			if len(acceptableVersionsDeduped) > 1 {
+				for i, v := range acceptableVersionsDeduped {
+					if flexver.Less(acceptableVersionsDeduped[i+1], v) {
+						fmt.Printf("Warning: Your acceptable versions list is out of order. ")
+						// Give a do you mean example
+						// Clone the list
+						acceptableVersionsDedupedClone := make([]string, len(acceptableVersionsDeduped))
+						copy(acceptableVersionsDedupedClone, acceptableVersionsDeduped)
+						flexver.VersionSlice(acceptableVersionsDedupedClone).Sort()
+						fmt.Printf("Did you mean %s?\n", strings.Join(acceptableVersionsDedupedClone, ", "))
+						if cmdshared.PromptYesNo("Would you like to fix this automatically? [Y/n] ") {
+							// If yes we'll just set the list to the sorted one
+							acceptableVersionsDeduped = acceptableVersionsDedupedClone
+							break
+						} else {
+							// If no we'll just continue
+							break
+						}
+					}
+				}
+			}
+			modpack.Options["acceptable-game-versions"] = acceptableVersionsDeduped
+			err = modpack.Write()
+			if err != nil {
+				fmt.Printf("Error writing pack: %s\n", err)
+				os.Exit(1)
+			}
+			// Print success message
+			prettyList := strings.Join(acceptableVersionsDeduped, ", ")
+			fmt.Printf("Set acceptable versions to %s\n", prettyList)
 		}
-		modpack.Options["acceptable-game-versions"] = acceptableVersionsDeduped
-		err = modpack.Write()
-		if err != nil {
-			fmt.Printf("Error writing pack: %s\n", err)
-			os.Exit(1)
-		}
-		// Print success message
-		prettyList := strings.Join(acceptableVersionsDeduped, ", ")
-		fmt.Printf("Set acceptable versions to %s\n", prettyList)
 	},
 }
 
 func init() {
 	settingsCmd.AddCommand(acceptableVersionsCommand)
+
+	// Add and remove flags for adding or removing specific versions
+	acceptableVersionsCommand.Flags().BoolP("add", "a", false, "Add a version to the list")
+	acceptableVersionsCommand.Flags().BoolP("remove", "r", false, "Remove a version from the list")
+	_ = viper.BindPFlag("settings.acceptable-versions.add", acceptableVersionsCommand.Flags().Lookup("add"))
+	_ = viper.BindPFlag("settings.acceptable-versions.remove", acceptableVersionsCommand.Flags().Lookup("remove"))
 }

--- a/settings/acceptable_versions.go
+++ b/settings/acceptable_versions.go
@@ -73,12 +73,7 @@ var acceptableVersionsCommand = &cobra.Command{
 				os.Exit(1)
 			}
 			// Remove the version from the list
-			for i, v := range currentVersions {
-				if v == acceptableVersion {
-					currentVersions = append(currentVersions[:i], currentVersions[i+1:]...)
-					break
-				}
-			}
+			currentVersions = slices.Delete(currentVersions, slices.Index(currentVersions, acceptableVersion), 1)
 			// Sort it just in case it's out of order
 			flexver.VersionSlice(currentVersions).Sort()
 			// Set the new list

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -1,0 +1,16 @@
+package settings
+
+import (
+	"github.com/packwiz/packwiz/cmd"
+	"github.com/spf13/cobra"
+)
+
+// settingsCmd represents the base command when called without any subcommands
+var settingsCmd = &cobra.Command{
+	Use:   "settings",
+	Short: "Manage pack settings",
+}
+
+func init() {
+	cmd.Add(settingsCmd)
+}


### PR DESCRIPTION
This command is pretty basic currently, it just takes a comma separated list of Minecraft versions. I'm somewhat torn between calling the root command `pack-settings` instead since it does edit pack settings but if it's left as `settings` it could be expanded to edit both global and pack settings. This is my first time working with cobra and its command system so feel free to suggest changes as I'm sure I'm not doing things perfectly. 

Closes #187 