### PR TITLE
Add migrate command

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -9,8 +9,8 @@ import (
 	"os"
 )
 
-// updateCmd represents the update command
-var updateCmd = &cobra.Command{
+// UpdateCmd represents the update command
+var UpdateCmd = &cobra.Command{
 	Use:     "update [name]",
 	Short:   "Update an external file (or all external files) in the modpack",
 	Aliases: []string{"upgrade"},
@@ -210,8 +210,8 @@ var updateCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(updateCmd)
+	rootCmd.AddCommand(UpdateCmd)
 
-	updateCmd.Flags().BoolP("all", "a", false, "Update all external files")
-	_ = viper.BindPFlag("update.all", updateCmd.Flags().Lookup("all"))
+	UpdateCmd.Flags().BoolP("all", "a", false, "Update all external files")
+	_ = viper.BindPFlag("update.all", UpdateCmd.Flags().Lookup("all"))
 }

--- a/cmdshared/mcversion.go
+++ b/cmdshared/mcversion.go
@@ -1,0 +1,52 @@
+package cmdshared
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/packwiz/packwiz/core"
+	"os"
+	"sort"
+	"time"
+)
+
+type McVersionManifest struct {
+	Latest struct {
+		Release  string `json:"release"`
+		Snapshot string `json:"snapshot"`
+	} `json:"latest"`
+	Versions []struct {
+		ID          string    `json:"id"`
+		Type        string    `json:"type"`
+		URL         string    `json:"url"`
+		Time        time.Time `json:"time"`
+		ReleaseTime time.Time `json:"releaseTime"`
+	} `json:"versions"`
+}
+
+func (m McVersionManifest) CheckValid(version string) {
+	for _, v := range m.Versions {
+		if v.ID == version {
+			return
+		}
+	}
+	fmt.Println("Given version is not a valid Minecraft version!")
+	os.Exit(1)
+}
+
+func GetValidMCVersions() (McVersionManifest, error) {
+	res, err := core.GetWithUA("https://launchermeta.mojang.com/mc/game/version_manifest.json", "application/json")
+	if err != nil {
+		return McVersionManifest{}, err
+	}
+	dec := json.NewDecoder(res.Body)
+	out := McVersionManifest{}
+	err = dec.Decode(&out)
+	if err != nil {
+		return McVersionManifest{}, err
+	}
+	// Sort by newest to oldest
+	sort.Slice(out.Versions, func(i, j int) bool {
+		return out.Versions[i].ReleaseTime.Before(out.Versions[j].ReleaseTime)
+	})
+	return out, nil
+}

--- a/cmdshared/utils.go
+++ b/cmdshared/utils.go
@@ -1,0 +1,16 @@
+package cmdshared
+
+import "strings"
+
+func GetRawForgeVersion(version string) string {
+	var wantedVersion string
+	// Check if we have a "-" in the version
+	if strings.Contains(version, "-") {
+		// We have a mcVersion-loaderVersion format
+		// Strip the mcVersion
+		wantedVersion = strings.Split(version, "-")[1]
+	} else {
+		wantedVersion = version
+	}
+	return wantedVersion
+}

--- a/core/versionutil.go
+++ b/core/versionutil.go
@@ -1,8 +1,10 @@
 package core
 
 import (
+	"encoding/json"
 	"encoding/xml"
 	"errors"
+	"fmt"
 	"github.com/unascribed/FlexVer/go/flexver"
 	"strings"
 )
@@ -157,4 +159,35 @@ func HighestSliceIndex(slice []string, values []string) int {
 		}
 	}
 	return highest
+}
+
+type ForgeRecommended struct {
+	Homepage string            `json:"homepage"`
+	Versions map[string]string `json:"promos"`
+}
+
+// GetForgeRecommended gets the recommended version of Forge for the given Minecraft version
+func GetForgeRecommended(mcVersion string) string {
+	res, err := GetWithUA("https://files.minecraftforge.net/net/minecraftforge/forge/promotions_slim.json", "application/json")
+	if err != nil {
+		return ""
+	}
+	dec := json.NewDecoder(res.Body)
+	out := ForgeRecommended{}
+	err = dec.Decode(&out)
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+	// Get mcVersion-recommended, if it doesn't exist then get mcVersion-latest
+	// If neither exist, return empty string
+	recommendedString := fmt.Sprintf("%s-recommended", mcVersion)
+	if out.Versions[recommendedString] != "" {
+		return out.Versions[recommendedString]
+	}
+	latestString := fmt.Sprintf("%s-latest", mcVersion)
+	if out.Versions[latestString] != "" {
+		return out.Versions[latestString]
+	}
+	return ""
 }

--- a/core/versionutil.go
+++ b/core/versionutil.go
@@ -96,7 +96,7 @@ func FetchMavenVersionPrefixedList(url string, friendlyName string) func(mcVersi
 		}
 		// Sort list to get largest version
 		flexver.VersionSlice(out.Versioning.Versions.Version).Sort()
-		return allowedVersions, allowedVersions[len(allowedVersions)-1], nil
+		return allowedVersions, allowedVersions[0], nil
 	}
 }
 

--- a/core/versionutil.go
+++ b/core/versionutil.go
@@ -97,8 +97,8 @@ func FetchMavenVersionPrefixedList(url string, friendlyName string) func(mcVersi
 			return allowedVersions, out.Versioning.Latest, nil
 		}
 		// Sort list to get largest version
-		flexver.VersionSlice(out.Versioning.Versions.Version).Sort()
-		return allowedVersions, allowedVersions[0], nil
+		flexver.VersionSlice(allowedVersions).Sort()
+		return allowedVersions, allowedVersions[len(allowedVersions)-1], nil
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	// Modules of packwiz
 	"github.com/packwiz/packwiz/cmd"
 	_ "github.com/packwiz/packwiz/curseforge"
+	_ "github.com/packwiz/packwiz/migrate"
 	_ "github.com/packwiz/packwiz/modrinth"
 	_ "github.com/packwiz/packwiz/settings"
 	_ "github.com/packwiz/packwiz/url"

--- a/migrate/loader.go
+++ b/migrate/loader.go
@@ -1,0 +1,25 @@
+package migrate
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+var loaderCommand = &cobra.Command{
+	Use:   "loader",
+	Short: "Migrate your loader versions to newer versions.",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if args[0] == "latest" {
+			fmt.Println("Updating to latest loader version")
+		} else if args[0] == "recommended" {
+			fmt.Println("Updating to recommended loader version")
+		} else {
+			fmt.Println("Updating to explicit loader version")
+		}
+	},
+}
+
+func init() {
+	migrateCmd.AddCommand(loaderCommand)
+}

--- a/migrate/loader.go
+++ b/migrate/loader.go
@@ -61,8 +61,20 @@ var loaderCommand = &cobra.Command{
 			}
 		} else if args[0] == "recommended" {
 			// TODO: Figure out a way to get the recommended version, this is Forge only
-			fmt.Println("Currently updating to the recommended loader version is not supported!")
-			os.Exit(1)
+			// Ensure we're on Forge
+			if !slices.Contains(currentLoader, "forge") {
+				fmt.Println("The recommended loader version is only available on Forge!")
+				os.Exit(1)
+			}
+			// We'll be updating to the recommended loader version
+			recommendedVer := core.GetForgeRecommended(mcVersion)
+			if recommendedVer == "" {
+				fmt.Println("Error getting recommended Forge version!")
+				os.Exit(1)
+			}
+			if ok := updatePackToVersion(recommendedVer, modpack, core.ModLoaders["forge"]); !ok {
+				os.Exit(1)
+			}
 		} else {
 			fmt.Println("Updating to explicit loader version")
 			// This one is easy :D
@@ -87,7 +99,9 @@ var loaderCommand = &cobra.Command{
 			} else {
 				// We're on Fabric or quilt
 				validateVersion(versions, args[0], loader)
-				_ = updatePackToVersion(args[0], modpack, loader)
+				if ok := updatePackToVersion(args[0], modpack, loader); !ok {
+					os.Exit(1)
+				}
 			}
 			// Write the pack to disk
 			err = modpack.Write()

--- a/migrate/loader.go
+++ b/migrate/loader.go
@@ -10,8 +10,8 @@ import (
 )
 
 var loaderCommand = &cobra.Command{
-	Use:   "loader",
-	Short: "Migrate your modloader version to newer versions.",
+	Use:   "loader [version|latest|recommended]",
+	Short: "Migrate your modloader version to a newer version.",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		modpack, err := core.LoadPack()

--- a/migrate/loader.go
+++ b/migrate/loader.go
@@ -2,7 +2,10 @@ package migrate
 
 import (
 	"fmt"
+	"github.com/packwiz/packwiz/core"
 	"github.com/spf13/cobra"
+	"golang.org/x/exp/slices"
+	"os"
 )
 
 var loaderCommand = &cobra.Command{
@@ -10,12 +13,71 @@ var loaderCommand = &cobra.Command{
 	Short: "Migrate your loader versions to newer versions.",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		modpack, err := core.LoadPack()
+		if err != nil {
+			// Check if it's a no such file or directory error
+			if os.IsNotExist(err) {
+				fmt.Println("No pack.toml file found, run 'packwiz init' to create one!")
+				os.Exit(1)
+			}
+			fmt.Printf("Error loading pack: %s\n", err)
+			os.Exit(1)
+		}
+		// Get our current loader
+		currentLoader := modpack.GetLoaders()
+		// Do some sanity checks on the current loader slice
+		if len(currentLoader) == 0 {
+			fmt.Println("No loader is currently set in your pack.toml!")
+			os.Exit(1)
+		} else if !slices.Contains(currentLoader, "quilt") && len(currentLoader) > 1 {
+			fmt.Println("You have multiple loaders set in your pack.toml, this is not supported!")
+			os.Exit(1)
+		}
+		// Get the Minecraft version for the pack
+		mcVersion, err := modpack.GetMCVersion()
+		if err != nil {
+			fmt.Printf("Error getting Minecraft version: %s\n", err)
+			os.Exit(1)
+		}
 		if args[0] == "latest" {
 			fmt.Println("Updating to latest loader version")
+			// We'll be updating to the latest loader version
+			for _, loader := range currentLoader {
+				loader, ok := core.ModLoaders[loader]
+				if !ok {
+					fmt.Printf("Unknown loader %s\n", loader)
+					continue
+				}
+				_, latest, err := loader.VersionListGetter(mcVersion)
+				if err != nil {
+					fmt.Printf("Error getting version list for %s: %s\n", loader.Name, err)
+					continue
+				}
+				// Check if the latest version is already set
+				if latest == modpack.Versions[loader.Name] {
+					fmt.Printf("Loader %s is already up to date!\n", loader.Name)
+					continue
+				}
+				// Set the latest version
+				modpack.Versions[loader.Name] = latest
+				fmt.Printf("Updated loader %s to version %s\n", loader.Name, latest)
+				// Write the pack to disk
+				err = modpack.Write()
+				if err != nil {
+					fmt.Printf("Error writing pack.toml: %s\n", err)
+					continue
+				}
+			}
 		} else if args[0] == "recommended" {
-			fmt.Println("Updating to recommended loader version")
+			// TODO: Figure out a way to get the recommended version, this is Forge only
+			fmt.Println("Currently updating to the recommended loader version is not supported!")
+			os.Exit(1)
 		} else {
 			fmt.Println("Updating to explicit loader version")
+			// Check if they're using quilt as we'll have 2 versions to update and will need to prompt for the versions
+			if slices.Contains(currentLoader, "quilt") {
+				// TODO: Prompt for the loader versions
+			}
 		}
 	},
 }

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -1,0 +1,16 @@
+package migrate
+
+import (
+	"github.com/packwiz/packwiz/cmd"
+	"github.com/spf13/cobra"
+)
+
+// migrateCmd represents the base command when called without any subcommands
+var migrateCmd = &cobra.Command{
+	Use:   "migrate",
+	Short: "Migrate your Minecraft and loader versions to newer versions.",
+}
+
+func init() {
+	cmd.Add(migrateCmd)
+}

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -7,7 +7,7 @@ import (
 
 // migrateCmd represents the base command when called without any subcommands
 var migrateCmd = &cobra.Command{
-	Use:   "migrate",
+	Use:   "migrate [minecraft|loader]",
 	Short: "Migrate your Minecraft and loader versions to newer versions.",
 }
 

--- a/migrate/minecraft.go
+++ b/migrate/minecraft.go
@@ -1,0 +1,70 @@
+package migrate
+
+import (
+	"fmt"
+	packCmd "github.com/packwiz/packwiz/cmd"
+	"github.com/packwiz/packwiz/cmdshared"
+	"github.com/packwiz/packwiz/core"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"os"
+)
+
+var minecraftCommand = &cobra.Command{
+	Use:     "minecraft",
+	Short:   "Migrate your Minecraft version to a newer version.",
+	Aliases: []string{"mc"},
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		modpack, err := core.LoadPack()
+		if err != nil {
+			// Check if it's a no such file or directory error
+			if os.IsNotExist(err) {
+				fmt.Println("No pack.toml file found, run 'packwiz init' to create one!")
+				os.Exit(1)
+			}
+			fmt.Printf("Error loading pack: %s\n", err)
+			os.Exit(1)
+		}
+		currentVersion, err := modpack.GetMCVersion()
+		if err != nil {
+			fmt.Printf("Error getting Minecraft version from pack: %s\n", err)
+			os.Exit(1)
+		}
+		wantedMCVersion := args[0]
+		if wantedMCVersion == currentVersion {
+			fmt.Printf("Minecraft version is already %s!\n", wantedMCVersion)
+			os.Exit(0)
+		}
+		mcVersions, err := cmdshared.GetValidMCVersions()
+		if err != nil {
+			fmt.Printf("Error getting Minecraft versions: %s\n", err)
+			os.Exit(1)
+		}
+		mcVersions.CheckValid(wantedMCVersion)
+		// Set the version in the pack
+		modpack.Versions["minecraft"] = wantedMCVersion
+		// Write the pack to disk
+		err = modpack.Write()
+		if err != nil {
+			fmt.Printf("Error writing pack.toml: %s\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Successfully updated Minecraft version to %s\n", wantedMCVersion)
+		// Prompt the user if they want to update the loader too while they're at it.
+		if cmdshared.PromptYesNo("Would you like to update your loader version to the latest version for this Minecraft version? [Y/n] ") {
+			// We'll run the loader command to update to latest
+			loaderCommand.Run(loaderCommand, []string{"latest"})
+		}
+		// Prompt the user to update their mods too.
+		if cmdshared.PromptYesNo("Would you like to update your mods to the latest versions for this Minecraft version? [Y/n] ") {
+			// Run the update command
+			viper.Set("update.all", true)
+			packCmd.UpdateCmd.Run(packCmd.UpdateCmd, []string{})
+		}
+	},
+}
+
+func init() {
+	migrateCmd.AddCommand(minecraftCommand)
+}

--- a/migrate/minecraft.go
+++ b/migrate/minecraft.go
@@ -11,7 +11,7 @@ import (
 )
 
 var minecraftCommand = &cobra.Command{
-	Use:     "minecraft",
+	Use:     "minecraft [version]",
 	Short:   "Migrate your Minecraft version to a newer version.",
 	Aliases: []string{"mc"},
 	Args:    cobra.ExactArgs(1),


### PR DESCRIPTION
This command will allow users to update their packs to newer loader and Minecraft versions. When updating Minecraft it will attempt to also update any mods that it can. 