### PR TITLE
Support for GitHub Releases

### DIFF
--- a/core/download.go
+++ b/core/download.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"golang.org/x/exp/slices"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"golang.org/x/exp/slices"
 )
 
 const UserAgent = "packwiz/packwiz"

--- a/github/github.go
+++ b/github/github.go
@@ -1,0 +1,70 @@
+package github
+
+import (
+	"github.com/packwiz/packwiz/cmd"
+	"github.com/packwiz/packwiz/core"
+	"github.com/spf13/cobra"
+)
+
+var githubCmd = &cobra.Command{
+	Use:     "github",
+	Aliases: []string{"gh"},
+	Short:   "Manage github-based mods",
+}
+
+func init() {
+	cmd.Add(githubCmd)
+	core.Updaters["github"] = ghUpdater{}
+}
+
+type ModReleases struct {
+	URL       string `json:"url"`
+	AssetsURL string `json:"assets_url"`
+	UploadURL string `json:"upload_url"`
+	HTMLURL   string `json:"html_url"`
+	ID        int    `json:"id"`
+	Author    struct {
+		Login             string `json:"login"`
+		ID                int    `json:"id"`
+		NodeID            string `json:"node_id"`
+		AvatarURL         string `json:"avatar_url"`
+		GravatarID        string `json:"gravatar_id"`
+		URL               string `json:"url"`
+		HTMLURL           string `json:"html_url"`
+		FollowersURL      string `json:"followers_url"`
+		FollowingURL      string `json:"following_url"`
+		GistsURL          string `json:"gists_url"`
+		StarredURL        string `json:"starred_url"`
+		SubscriptionsURL  string `json:"subscriptions_url"`
+		OrganizationsURL  string `json:"organizations_url"`
+		ReposURL          string `json:"repos_url"`
+		EventsURL         string `json:"events_url"`
+		ReceivedEventsURL string `json:"received_events_url"`
+		Type              string `json:"type"`
+		SiteAdmin         bool   `json:"site_admin"`
+	} `json:"author"`
+	NodeID          string  `json:"node_id"`
+	TagName         string  `json:"tag_name"`
+	TargetCommitish string  `json:"target_commitish"`
+	Name            string  `json:"name"`
+	Draft           bool    `json:"draft"`
+	Prerelease      bool    `json:"prerelease"`
+	CreatedAt       string  `json:"created_at"`
+	PublishedAt     string  `json:"published_at"`
+	Assets          []Asset `json:"assets"`
+	TarballURL      string  `json:"tarball_url"`
+	ZipballURL      string  `json:"zipball_url"`
+	Body            string  `json:"body"`
+	Reactions       struct {
+		URL        string `json:"url"`
+		TotalCount int    `json:"total_count"`
+		Num1       int    `json:"+1"`
+		Num10      int    `json:"-1"`
+		Laugh      int    `json:"laugh"`
+		Hooray     int    `json:"hooray"`
+		Confused   int    `json:"confused"`
+		Heart      int    `json:"heart"`
+		Rocket     int    `json:"rocket"`
+		Eyes       int    `json:"eyes"`
+	} `json:"reactions"`
+}

--- a/github/github.go
+++ b/github/github.go
@@ -1,6 +1,14 @@
 package github
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
 	"github.com/packwiz/packwiz/cmd"
 	"github.com/packwiz/packwiz/core"
 	"github.com/spf13/cobra"
@@ -17,54 +25,163 @@ func init() {
 	core.Updaters["github"] = ghUpdater{}
 }
 
+func fetchRepo(slug string) (Repo, error) {
+	var repo Repo
+	res, err := http.Get(githubApiUrl + "repos/" + slug)
+
+	if err != nil {
+		return repo, err
+	}
+
+	defer res.Body.Close()
+
+	repoBody, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return repo, err
+	}
+
+	err = json.Unmarshal(repoBody, &repo)
+	if err != nil {
+		return repo, err
+	}
+	return repo, nil
+}
+
+func fetchMod(slug string) (Mod, error) {
+
+	var mod Mod
+
+	repo, err := fetchRepo(slug)
+
+	if err != nil {
+		return mod, err
+	}
+
+	release, err := getLatestVersion(slug, "")
+
+	if err != nil {
+		return mod, err
+	}
+
+	mod = Mod{
+		ID:          repo.Name,
+		Slug:        slug,
+		Team:        repo.Owner.Login,
+		Title:       repo.Name,
+		Description: repo.Description,
+		Published:   repo.CreatedAt,
+		Updated:     release.CreatedAt,
+		License:     repo.License,
+		ClientSide:  "unknown",
+		ServerSide:  "unknown",
+		Categories:  repo.Topics,
+	}
+	if mod.ID == "" {
+		return mod, errors.New("invalid json whilst fetching mod: " + slug)
+	}
+
+	return mod, nil
+
+}
+
 type ModReleases struct {
-	URL       string `json:"url"`
-	AssetsURL string `json:"assets_url"`
-	UploadURL string `json:"upload_url"`
-	HTMLURL   string `json:"html_url"`
-	ID        int    `json:"id"`
-	Author    struct {
-		Login             string `json:"login"`
-		ID                int    `json:"id"`
-		NodeID            string `json:"node_id"`
-		AvatarURL         string `json:"avatar_url"`
-		GravatarID        string `json:"gravatar_id"`
-		URL               string `json:"url"`
-		HTMLURL           string `json:"html_url"`
-		FollowersURL      string `json:"followers_url"`
-		FollowingURL      string `json:"following_url"`
-		GistsURL          string `json:"gists_url"`
-		StarredURL        string `json:"starred_url"`
-		SubscriptionsURL  string `json:"subscriptions_url"`
-		OrganizationsURL  string `json:"organizations_url"`
-		ReposURL          string `json:"repos_url"`
-		EventsURL         string `json:"events_url"`
-		ReceivedEventsURL string `json:"received_events_url"`
-		Type              string `json:"type"`
-		SiteAdmin         bool   `json:"site_admin"`
-	} `json:"author"`
+	URL             string  `json:"url"`
 	NodeID          string  `json:"node_id"`
 	TagName         string  `json:"tag_name"`
 	TargetCommitish string  `json:"target_commitish"` // The branch of the release
 	Name            string  `json:"name"`
-	Draft           bool    `json:"draft"`
-	Prerelease      bool    `json:"prerelease"`
 	CreatedAt       string  `json:"created_at"`
-	PublishedAt     string  `json:"published_at"`
 	Assets          []Asset `json:"assets"`
-	TarballURL      string  `json:"tarball_url"`
-	ZipballURL      string  `json:"zipball_url"`
-	Body            string  `json:"body"`
-	Reactions       struct {
-		URL        string `json:"url"`
-		TotalCount int    `json:"total_count"`
-		Num1       int    `json:"+1"`
-		Num10      int    `json:"-1"`
-		Laugh      int    `json:"laugh"`
-		Hooray     int    `json:"hooray"`
-		Confused   int    `json:"confused"`
-		Heart      int    `json:"heart"`
-		Rocket     int    `json:"rocket"`
-		Eyes       int    `json:"eyes"`
-	} `json:"reactions"`
+}
+
+type Asset struct {
+	URL                string    `json:"url"`
+	Name               string    `json:"name"`
+	UpdatedAt          time.Time `json:"updated_at"`
+	BrowserDownloadURL string    `json:"browser_download_url"`
+}
+
+type Repo struct {
+	ID       int    `json:"id"`
+	Name     string `json:"name"`
+	FullName string `json:"full_name"`
+	Owner    struct {
+		Login string `json:"login"`
+	} `json:"owner"`
+	Description string `json:"description"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+	License     struct {
+		Key    string `json:"key"`
+		Name   string `json:"name"`
+		SpdxID string `json:"spdx_id"`
+		URL    string `json:"url"`
+		NodeID string `json:"node_id"`
+	} `json:"license"`
+	Topics []string `json:"topics"`
+}
+
+func (u ghUpdateData) ToMap() (map[string]interface{}, error) {
+	newMap := make(map[string]interface{})
+	err := mapstructure.Decode(u, &newMap)
+	return newMap, err
+}
+
+type License struct {
+	Id   string `json:"id"`   //The license id of a mod, retrieved from the licenses get route
+	Name string `json:"name"` //The long for name of a license
+	Url  string `json:"url"`  //The URL to this license
+}
+
+type Mod struct {
+	ID          string `json:"id"`          //The ID of the mod, encoded as a base62 string
+	Slug        string `json:"slug"`        //The slug of a mod, used for vanity URLs
+	Team        string `json:"team"`        //The id of the team that has ownership of this mod
+	Title       string `json:"title"`       //The title or name of the mod
+	Description string `json:"description"` //A short description of the mod
+	// Body        string   `json:"body"`        //A long form description of the mod.
+	// BodyUrl     string   `json:"body_url"`    //DEPRECATED The link to the long description of the mod (Optional)
+	Published string `json:"published"` //The date at which the mod was first published
+	Updated   string `json:"updated"`   //The date at which the mod was updated
+	License   struct {
+		Key    string `json:"key"`
+		Name   string `json:"name"`
+		SpdxID string `json:"spdx_id"`
+		URL    string `json:"url"`
+		NodeID string `json:"node_id"`
+	} `json:"license"`
+	ClientSide string `json:"client_side"` //The support range for the client mod - required, optional, unsupported, or unknown
+	ServerSide string `json:"server_side"` //The support range for the server mod - required, optional, unsupported, or unknown
+	// Downloads  int      `json:"downloads"`   //The total number of downloads the mod has
+	Categories []string `json:"categories"`  //A list of the categories that the mod is in
+	Versions   []string `json:"versions"`    //A list of ids for versions of the mod
+	IconUrl    string   `json:"icon_url"`    //The URL of the icon of the mod (Optional)
+	IssuesUrl  string   `json:"issues_url"`  //An optional link to where to submit bugs or issues with the mod (Optional)
+	SourceUrl  string   `json:"source_url"`  //An optional link to the source code for the mod (Optional)
+	WikiUrl    string   `json:"wiki_url"`    //An optional link to the mod's wiki page or other relevant information (Optional)
+	DiscordUrl string   `json:"discord_url"` //An optional link to the mod's discord (Optional)
+}
+
+func (u Asset) getSha1() (string, error) {
+	// TODO potentionally cache downloads to speed things up and avoid getting ratelimited by github!
+	mainHasher, err := core.GetHashImpl("sha1")
+	resp, err := http.Get(u.BrowserDownloadURL)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode == 404 {
+		return "", fmt.Errorf("Asset not found")
+	}
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("Invalid response code: %d", resp.StatusCode)
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	mainHasher.Write(body)
+
+	hash := mainHasher.Sum(nil)
+
+	return mainHasher.HashToString(hash), nil
 }

--- a/github/github.go
+++ b/github/github.go
@@ -45,7 +45,7 @@ type ModReleases struct {
 	} `json:"author"`
 	NodeID          string  `json:"node_id"`
 	TagName         string  `json:"tag_name"`
-	TargetCommitish string  `json:"target_commitish"`
+	TargetCommitish string  `json:"target_commitish"` // The branch of the release
 	Name            string  `json:"name"`
 	Draft           bool    `json:"draft"`
 	Prerelease      bool    `json:"prerelease"`

--- a/github/github.go
+++ b/github/github.go
@@ -4,9 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
-	"time"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/packwiz/packwiz/cmd"
@@ -27,15 +26,15 @@ func init() {
 
 func fetchRepo(slug string) (Repo, error) {
 	var repo Repo
-	res, err := http.Get(githubApiUrl + "repos/" + slug)
 
+	res, err := http.Get(githubApiUrl + "repos/" + slug)
 	if err != nil {
 		return repo, err
 	}
 
 	defer res.Body.Close()
 
-	repoBody, err := ioutil.ReadAll(res.Body)
+	repoBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		return repo, err
 	}
@@ -44,49 +43,24 @@ func fetchRepo(slug string) (Repo, error) {
 	if err != nil {
 		return repo, err
 	}
+
+	if repo.FullName == "" {
+		return repo, errors.New("invalid json while fetching mod: " + slug)
+	}
+
 	return repo, nil
 }
 
-func fetchMod(slug string) (Mod, error) {
-
-	var mod Mod
-
-	repo, err := fetchRepo(slug)
-
-	if err != nil {
-		return mod, err
-	}
-
-	release, err := getLatestVersion(slug, "")
-
-	if err != nil {
-		return mod, err
-	}
-
-	mod = Mod{
-		ID:          repo.Name,
-		Slug:        slug,
-		Team:        repo.Owner.Login,
-		Title:       repo.Name,
-		Description: repo.Description,
-		Published:   repo.CreatedAt,
-		Updated:     release.CreatedAt,
-		License:     repo.License,
-		ClientSide:  "unknown",
-		ServerSide:  "unknown",
-		Categories:  repo.Topics,
-	}
-	if mod.ID == "" {
-		return mod, errors.New("invalid json whilst fetching mod: " + slug)
-	}
-
-	return mod, nil
-
+type Repo struct {
+	ID       int    `json:"id"`
+	NodeID   string `json:"node_id"`   // TODO: use this with GH API, instead of name (to acct. for repo renames?) + store in mod.pw.toml
+	Name     string `json:"name"`      // "hello_world"
+	FullName string `json:"full_name"` // "owner/hello_world"
 }
 
-type ModReleases struct {
+type Release struct {
 	URL             string  `json:"url"`
-	NodeID          string  `json:"node_id"`
+	NodeID          string  `json:"node_id"` // TODO: probably also use this with GH API
 	TagName         string  `json:"tag_name"`
 	TargetCommitish string  `json:"target_commitish"` // The branch of the release
 	Name            string  `json:"name"`
@@ -95,30 +69,9 @@ type ModReleases struct {
 }
 
 type Asset struct {
-	URL                string    `json:"url"`
-	Name               string    `json:"name"`
-	UpdatedAt          time.Time `json:"updated_at"`
-	BrowserDownloadURL string    `json:"browser_download_url"`
-}
-
-type Repo struct {
-	ID       int    `json:"id"`
-	Name     string `json:"name"`
-	FullName string `json:"full_name"`
-	Owner    struct {
-		Login string `json:"login"`
-	} `json:"owner"`
-	Description string `json:"description"`
-	CreatedAt   string `json:"created_at"`
-	UpdatedAt   string `json:"updated_at"`
-	License     struct {
-		Key    string `json:"key"`
-		Name   string `json:"name"`
-		SpdxID string `json:"spdx_id"`
-		URL    string `json:"url"`
-		NodeID string `json:"node_id"`
-	} `json:"license"`
-	Topics []string `json:"topics"`
+	URL                string `json:"url"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+	Name               string `json:"name"`
 }
 
 func (u ghUpdateData) ToMap() (map[string]interface{}, error) {
@@ -127,58 +80,28 @@ func (u ghUpdateData) ToMap() (map[string]interface{}, error) {
 	return newMap, err
 }
 
-type License struct {
-	Id   string `json:"id"`   //The license id of a mod, retrieved from the licenses get route
-	Name string `json:"name"` //The long for name of a license
-	Url  string `json:"url"`  //The URL to this license
-}
-
-type Mod struct {
-	ID          string `json:"id"`          //The ID of the mod, encoded as a base62 string
-	Slug        string `json:"slug"`        //The slug of a mod, used for vanity URLs
-	Team        string `json:"team"`        //The id of the team that has ownership of this mod
-	Title       string `json:"title"`       //The title or name of the mod
-	Description string `json:"description"` //A short description of the mod
-	// Body        string   `json:"body"`        //A long form description of the mod.
-	// BodyUrl     string   `json:"body_url"`    //DEPRECATED The link to the long description of the mod (Optional)
-	Published string `json:"published"` //The date at which the mod was first published
-	Updated   string `json:"updated"`   //The date at which the mod was updated
-	License   struct {
-		Key    string `json:"key"`
-		Name   string `json:"name"`
-		SpdxID string `json:"spdx_id"`
-		URL    string `json:"url"`
-		NodeID string `json:"node_id"`
-	} `json:"license"`
-	ClientSide string `json:"client_side"` //The support range for the client mod - required, optional, unsupported, or unknown
-	ServerSide string `json:"server_side"` //The support range for the server mod - required, optional, unsupported, or unknown
-	// Downloads  int      `json:"downloads"`   //The total number of downloads the mod has
-	Categories []string `json:"categories"`  //A list of the categories that the mod is in
-	Versions   []string `json:"versions"`    //A list of ids for versions of the mod
-	IconUrl    string   `json:"icon_url"`    //The URL of the icon of the mod (Optional)
-	IssuesUrl  string   `json:"issues_url"`  //An optional link to where to submit bugs or issues with the mod (Optional)
-	SourceUrl  string   `json:"source_url"`  //An optional link to the source code for the mod (Optional)
-	WikiUrl    string   `json:"wiki_url"`    //An optional link to the mod's wiki page or other relevant information (Optional)
-	DiscordUrl string   `json:"discord_url"` //An optional link to the mod's discord (Optional)
-}
-
-func (u Asset) getSha1() (string, error) {
+func (u Asset) getSha256() (string, error) {
 	// TODO potentionally cache downloads to speed things up and avoid getting ratelimited by github!
-	mainHasher, err := core.GetHashImpl("sha1")
+	mainHasher, err := core.GetHashImpl("sha256")
+	if err != nil {
+		return "", err
+	}
+
 	resp, err := http.Get(u.BrowserDownloadURL)
 	if err != nil {
 		return "", err
 	}
-	if resp.StatusCode == 404 {
-		return "", fmt.Errorf("Asset not found")
-	}
-
 	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("Invalid response code: %d", resp.StatusCode)
+		return "", fmt.Errorf("invalid response status: %v", resp.StatusCode)
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
 	mainHasher.Write(body)
 
 	hash := mainHasher.Sum(nil)

--- a/github/install.go
+++ b/github/install.go
@@ -134,6 +134,10 @@ func installRelease(repo Repo, release Release, regex string, pack core.Pack) er
 		}
 	}
 
+	if len(files) == 0 {
+		return errors.New("release doesn't have any assets matching regex")
+	}
+
 	if len(files) > 1 {
 		// TODO: also print file names
 		return errors.New("release has more than one asset matching regex")

--- a/github/install.go
+++ b/github/install.go
@@ -224,11 +224,7 @@ func installVersion(mod Mod, version ModReleases, pack core.Pack) error {
 	if folder == "" {
 		folder = "mods"
 	}
-	if mod.Slug != "" {
-		path = modMeta.SetMetaPath(filepath.Join(viper.GetString("meta-folder-base"), folder, mod.Slug+core.MetaExtension))
-	} else {
-		path = modMeta.SetMetaPath(filepath.Join(viper.GetString("meta-folder-base"), folder, mod.Title+core.MetaExtension))
-	}
+	path = modMeta.SetMetaPath(filepath.Join(viper.GetString("meta-folder-base"), folder, mod.Title+core.MetaExtension))
 
 	// If the file already exists, this will overwrite it!!!
 	// TODO: Should this be improved?

--- a/github/install.go
+++ b/github/install.go
@@ -54,7 +54,11 @@ var installCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		installMod(repo, pack)
+		err = installMod(repo, pack)
+		if err != nil {
+			fmt.Printf("Failed to add project: %s\n", err)
+			os.Exit(1)
+		}
 	},
 }
 
@@ -168,5 +172,25 @@ func installRelease(repo Repo, release Release, pack core.Pack) error {
 	if err != nil {
 		return err
 	}
-	return index.RefreshFileWithHash(path, format, hash, true)
+
+	err = index.RefreshFileWithHash(path, format, hash, true)
+	if err != nil {
+		return err
+	}
+	err = index.Write()
+	if err != nil {
+		return err
+	}
+	err = pack.UpdateIndexHash()
+	if err != nil {
+		return err
+	}
+	err = pack.Write()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Project \"%s\" successfully added! (%s)\n", repo.Name, file.Name)
+	return nil
+}
 }

--- a/github/install.go
+++ b/github/install.go
@@ -1,0 +1,504 @@
+package github
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/packwiz/packwiz/core"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var modSiteRegex = regexp.MustCompile("modrinth\\.com/mod/([^/]+)/?$")
+var versionSiteRegex = regexp.MustCompile("modrinth\\.com/mod/([^/]+)/version/([^/]+)/?$")
+
+// installCmd represents the install command
+var installCmd = &cobra.Command{
+	Use:     "install [mod]",
+	Short:   "Install a mod from a github URL",
+	Aliases: []string{"add", "get"},
+	Args:    cobra.ArbitraryArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		pack, err := core.LoadPack()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		if len(args) == 0 || len(args[0]) == 0 {
+			fmt.Println("You must specify a mod.")
+			os.Exit(1)
+		}
+		if strings.HasSuffix(args[0], "/") {
+			fmt.Println("Url cant have a leading slash!")
+			os.Exit(1)
+		}
+
+		slug := strings.Replace(args[0], "https://github.com/", "", 1)
+
+		mod, err := fetchMod(slug)
+
+		installMod(mod, pack)
+	},
+}
+
+func init() {
+	githubCmd.AddCommand(installCmd)
+}
+
+const githubApiUrl = "https://api.github.com/"
+
+func fetchMod(slug string) (Mod, error) {
+	var modReleases []ModReleases
+	var mod Mod
+	resp, err := http.Get(githubApiUrl + "repos/" + slug + "/releases")
+	if err != nil {
+		return mod, err
+	}
+
+	if resp.StatusCode == 404 {
+		return mod, fmt.Errorf("mod not found (for URL %v)", githubApiUrl+"repos/"+slug+"/releases")
+	}
+
+	if resp.StatusCode != 200 {
+		return mod, fmt.Errorf("invalid response status %v for URL %v", resp.Status, githubApiUrl+"repos/"+slug+"/releases")
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return mod, err
+	}
+
+	err = json.Unmarshal(body, &modReleases)
+	if err != nil {
+		return mod, err
+	}
+
+	var repoData Repo
+
+	repoResp, err := http.Get(githubApiUrl + "repos/" + slug)
+
+	defer repoResp.Body.Close()
+	repoBody, err := ioutil.ReadAll(repoResp.Body)
+	if err != nil {
+		return mod, err
+	}
+
+	err = json.Unmarshal(repoBody, &repoData)
+	if err != nil {
+		return mod, err
+	}
+
+	release := modReleases[0]
+
+	mod = Mod{
+		ID:          repoData.Name,
+		Slug:        slug,
+		Team:        repoData.Owner.Login,
+		Title:       repoData.Name,
+		Description: repoData.Description,
+		Published:   repoData.CreatedAt,
+		Updated:     release.CreatedAt,
+		License:     repoData.License,
+		ClientSide:  "unknown",
+		ServerSide:  "unknown",
+		Categories:  repoData.Topics,
+	}
+	if mod.ID == "" {
+		return mod, errors.New("invalid json whilst fetching mod: " + slug)
+	}
+
+	return mod, nil
+
+}
+
+func installMod(mod Mod, pack core.Pack) error {
+	fmt.Printf("Found mod %s: '%s'.\n", mod.Title, mod.Description)
+
+	latestVersion, err := getLatestVersion(mod.Slug, pack)
+	if err != nil {
+		return fmt.Errorf("failed to get latest version: %v", err)
+	}
+	if latestVersion.URL == "" {
+		return errors.New("mod is not available for this Minecraft version (use the acceptable-game-versions option to accept more) or mod loader")
+	}
+
+	return installVersion(mod, latestVersion, pack)
+}
+
+func getLatestVersion(slug string, pack core.Pack) (ModReleases, error) {
+	var modReleases []ModReleases
+	var release ModReleases
+
+	resp, err := http.Get(githubApiUrl + "repos/" + slug + "/releases")
+	if err != nil {
+		return release, err
+	}
+
+	if resp.StatusCode == 404 {
+		return release, fmt.Errorf("mod not found (for URL %v)", githubApiUrl+"repos/"+slug+"/releases")
+	}
+
+	if resp.StatusCode != 200 {
+		return release, fmt.Errorf("invalid response status %v for URL %v", resp.Status, githubApiUrl+"repos/"+slug+"/releases")
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return release, err
+	}
+	err = json.Unmarshal(body, &modReleases)
+	if err != nil {
+		return release, err
+	}
+
+	return modReleases[0], nil
+}
+
+func installVersion(mod Mod, version ModReleases, pack core.Pack) error {
+	var files = version.Assets
+
+	if len(files) == 0 {
+		return errors.New("version doesn't have any files attached")
+	}
+
+	// TODO: add some way to allow users to pick which file to install?
+	var file = files[0]
+	for _, v := range version.Assets {
+		if strings.HasSuffix(v.Name, ".jar") {
+			file = v
+		}
+	}
+
+	//Install the file
+	fmt.Printf("Installing %s from version %s\n", file.URL, version.Name)
+	index, err := pack.LoadIndex()
+	if err != nil {
+		return err
+	}
+
+	updateMap := make(map[string]map[string]interface{})
+
+	updateMap["github"], err = ghUpdateData{
+		ModID:            mod.ID,
+		InstalledVersion: version.TagName,
+	}.ToMap()
+	if err != nil {
+		return err
+	}
+
+	// side := mod.getSide()
+	// if side == "" {
+	// 	return errors.New("version doesn't have a side that's supported. Server: " + mod.ServerSide + " Client: " + mod.ClientSide)
+	// }
+
+	hash, error := file.getSha256()
+	if error != nil || hash == "" {
+		return errors.New("file doesn't have a hash")
+	}
+
+	modMeta := core.Mod{
+		Name:     mod.Title,
+		FileName: file.Name,
+		Side:     "unknown",
+		Download: core.ModDownload{
+			URL:        file.BrowserDownloadURL,
+			HashFormat: "sha256",
+			Hash:       hash,
+		},
+		Update: updateMap,
+	}
+	var path string
+	folder := viper.GetString("meta-folder")
+	if folder == "" {
+		folder = "mods"
+	}
+	if mod.Slug != "" {
+		path = modMeta.SetMetaPath(filepath.Join(viper.GetString("meta-folder-base"), folder, mod.Slug+core.MetaExtension))
+	} else {
+		path = modMeta.SetMetaPath(filepath.Join(viper.GetString("meta-folder-base"), folder, mod.Title+core.MetaExtension))
+	}
+
+	// If the file already exists, this will overwrite it!!!
+	// TODO: Should this be improved?
+	// Current strategy is to go ahead and do stuff without asking, with the assumption that you are using
+	// VCS anyway.
+
+	format, hash, err := modMeta.Write()
+	if err != nil {
+		return err
+	}
+	err = index.RefreshFileWithHash(path, format, hash, true)
+	if err != nil {
+		return err
+	}
+	err = index.Write()
+	if err != nil {
+		return err
+	}
+	err = pack.UpdateIndexHash()
+	if err != nil {
+		return err
+	}
+	err = pack.Write()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (u ghUpdateData) ToMap() (map[string]interface{}, error) {
+	newMap := make(map[string]interface{})
+	err := mapstructure.Decode(u, &newMap)
+	return newMap, err
+}
+
+type License struct {
+	Id   string `json:"id"`   //The license id of a mod, retrieved from the licenses get route
+	Name string `json:"name"` //The long for name of a license
+	Url  string `json:"url"`  //The URL to this license
+}
+
+type Mod struct {
+	ID          string `json:"id"`          //The ID of the mod, encoded as a base62 string
+	Slug        string `json:"slug"`        //The slug of a mod, used for vanity URLs
+	Team        string `json:"team"`        //The id of the team that has ownership of this mod
+	Title       string `json:"title"`       //The title or name of the mod
+	Description string `json:"description"` //A short description of the mod
+	// Body        string   `json:"body"`        //A long form description of the mod.
+	// BodyUrl     string   `json:"body_url"`    //DEPRECATED The link to the long description of the mod (Optional)
+	Published string `json:"published"` //The date at which the mod was first published
+	Updated   string `json:"updated"`   //The date at which the mod was updated
+	License   struct {
+		Key    string `json:"key"`
+		Name   string `json:"name"`
+		SpdxID string `json:"spdx_id"`
+		URL    string `json:"url"`
+		NodeID string `json:"node_id"`
+	} `json:"license"`
+	ClientSide string `json:"client_side"` //The support range for the client mod - required, optional, unsupported, or unknown
+	ServerSide string `json:"server_side"` //The support range for the server mod - required, optional, unsupported, or unknown
+	// Downloads  int      `json:"downloads"`   //The total number of downloads the mod has
+	Categories []string `json:"categories"`  //A list of the categories that the mod is in
+	Versions   []string `json:"versions"`    //A list of ids for versions of the mod
+	IconUrl    string   `json:"icon_url"`    //The URL of the icon of the mod (Optional)
+	IssuesUrl  string   `json:"issues_url"`  //An optional link to where to submit bugs or issues with the mod (Optional)
+	SourceUrl  string   `json:"source_url"`  //An optional link to the source code for the mod (Optional)
+	WikiUrl    string   `json:"wiki_url"`    //An optional link to the mod's wiki page or other relevant information (Optional)
+	DiscordUrl string   `json:"discord_url"` //An optional link to the mod's discord (Optional)
+}
+
+type Asset struct {
+	URL      string      `json:"url"`
+	ID       int         `json:"id"`
+	NodeID   string      `json:"node_id"`
+	Name     string      `json:"name"`
+	Label    interface{} `json:"label"`
+	Uploader struct {
+		Login             string `json:"login"`
+		ID                int    `json:"id"`
+		NodeID            string `json:"node_id"`
+		AvatarURL         string `json:"avatar_url"`
+		GravatarID        string `json:"gravatar_id"`
+		URL               string `json:"url"`
+		HTMLURL           string `json:"html_url"`
+		FollowersURL      string `json:"followers_url"`
+		FollowingURL      string `json:"following_url"`
+		GistsURL          string `json:"gists_url"`
+		StarredURL        string `json:"starred_url"`
+		SubscriptionsURL  string `json:"subscriptions_url"`
+		OrganizationsURL  string `json:"organizations_url"`
+		ReposURL          string `json:"repos_url"`
+		EventsURL         string `json:"events_url"`
+		ReceivedEventsURL string `json:"received_events_url"`
+		Type              string `json:"type"`
+		SiteAdmin         bool   `json:"site_admin"`
+	} `json:"uploader"`
+	ContentType        string    `json:"content_type"`
+	State              string    `json:"state"`
+	Size               int       `json:"size"`
+	DownloadCount      int       `json:"download_count"`
+	CreatedAt          time.Time `json:"created_at"`
+	UpdatedAt          time.Time `json:"updated_at"`
+	BrowserDownloadURL string    `json:"browser_download_url"`
+}
+
+func (u Asset) getSha256() (string, error) {
+	// TODO potentionally cache downloads to speed things up and avoid getting ratelimited by github!
+	file, err := os.CreateTemp("", "download")
+
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	mainHasher, err := core.GetHashImpl("sha256")
+	resp, err := http.Get(u.BrowserDownloadURL)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode == 404 {
+		return "", fmt.Errorf("Asset not found")
+	}
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("Invalid response code: %d", resp.StatusCode)
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+
+	file.Write(body)
+
+	h := sha256.New()
+	if _, err := io.Copy(h, file); err != nil {
+		log.Fatal(err)
+	}
+
+	hash := h.Sum(nil)
+
+	defer os.Remove(file.Name())
+
+	return mainHasher.HashToString(hash), nil
+}
+
+type Repo struct {
+	ID       int    `json:"id"`
+	NodeID   string `json:"node_id"`
+	Name     string `json:"name"`
+	FullName string `json:"full_name"`
+	Private  bool   `json:"private"`
+	Owner    struct {
+		Login             string `json:"login"`
+		ID                int    `json:"id"`
+		NodeID            string `json:"node_id"`
+		AvatarURL         string `json:"avatar_url"`
+		GravatarID        string `json:"gravatar_id"`
+		URL               string `json:"url"`
+		HTMLURL           string `json:"html_url"`
+		FollowersURL      string `json:"followers_url"`
+		FollowingURL      string `json:"following_url"`
+		GistsURL          string `json:"gists_url"`
+		StarredURL        string `json:"starred_url"`
+		SubscriptionsURL  string `json:"subscriptions_url"`
+		OrganizationsURL  string `json:"organizations_url"`
+		ReposURL          string `json:"repos_url"`
+		EventsURL         string `json:"events_url"`
+		ReceivedEventsURL string `json:"received_events_url"`
+		Type              string `json:"type"`
+		SiteAdmin         bool   `json:"site_admin"`
+	} `json:"owner"`
+	HTMLURL          string      `json:"html_url"`
+	Description      string      `json:"description"`
+	Fork             bool        `json:"fork"`
+	URL              string      `json:"url"`
+	ForksURL         string      `json:"forks_url"`
+	KeysURL          string      `json:"keys_url"`
+	CollaboratorsURL string      `json:"collaborators_url"`
+	TeamsURL         string      `json:"teams_url"`
+	HooksURL         string      `json:"hooks_url"`
+	IssueEventsURL   string      `json:"issue_events_url"`
+	EventsURL        string      `json:"events_url"`
+	AssigneesURL     string      `json:"assignees_url"`
+	BranchesURL      string      `json:"branches_url"`
+	TagsURL          string      `json:"tags_url"`
+	BlobsURL         string      `json:"blobs_url"`
+	GitTagsURL       string      `json:"git_tags_url"`
+	GitRefsURL       string      `json:"git_refs_url"`
+	TreesURL         string      `json:"trees_url"`
+	StatusesURL      string      `json:"statuses_url"`
+	LanguagesURL     string      `json:"languages_url"`
+	StargazersURL    string      `json:"stargazers_url"`
+	ContributorsURL  string      `json:"contributors_url"`
+	SubscribersURL   string      `json:"subscribers_url"`
+	SubscriptionURL  string      `json:"subscription_url"`
+	CommitsURL       string      `json:"commits_url"`
+	GitCommitsURL    string      `json:"git_commits_url"`
+	CommentsURL      string      `json:"comments_url"`
+	IssueCommentURL  string      `json:"issue_comment_url"`
+	ContentsURL      string      `json:"contents_url"`
+	CompareURL       string      `json:"compare_url"`
+	MergesURL        string      `json:"merges_url"`
+	ArchiveURL       string      `json:"archive_url"`
+	DownloadsURL     string      `json:"downloads_url"`
+	IssuesURL        string      `json:"issues_url"`
+	PullsURL         string      `json:"pulls_url"`
+	MilestonesURL    string      `json:"milestones_url"`
+	NotificationsURL string      `json:"notifications_url"`
+	LabelsURL        string      `json:"labels_url"`
+	ReleasesURL      string      `json:"releases_url"`
+	DeploymentsURL   string      `json:"deployments_url"`
+	CreatedAt        string      `json:"created_at"`
+	UpdatedAt        string      `json:"updated_at"`
+	PushedAt         string      `json:"pushed_at"`
+	GitURL           string      `json:"git_url"`
+	SSHURL           string      `json:"ssh_url"`
+	CloneURL         string      `json:"clone_url"`
+	SvnURL           string      `json:"svn_url"`
+	Homepage         string      `json:"homepage"`
+	Size             int         `json:"size"`
+	StargazersCount  int         `json:"stargazers_count"`
+	WatchersCount    int         `json:"watchers_count"`
+	Language         string      `json:"language"`
+	HasIssues        bool        `json:"has_issues"`
+	HasProjects      bool        `json:"has_projects"`
+	HasDownloads     bool        `json:"has_downloads"`
+	HasWiki          bool        `json:"has_wiki"`
+	HasPages         bool        `json:"has_pages"`
+	ForksCount       int         `json:"forks_count"`
+	MirrorURL        interface{} `json:"mirror_url"`
+	Archived         bool        `json:"archived"`
+	Disabled         bool        `json:"disabled"`
+	OpenIssuesCount  int         `json:"open_issues_count"`
+	License          struct {
+		Key    string `json:"key"`
+		Name   string `json:"name"`
+		SpdxID string `json:"spdx_id"`
+		URL    string `json:"url"`
+		NodeID string `json:"node_id"`
+	} `json:"license"`
+	AllowForking   bool        `json:"allow_forking"`
+	IsTemplate     bool        `json:"is_template"`
+	Topics         []string    `json:"topics"`
+	Visibility     string      `json:"visibility"`
+	Forks          int         `json:"forks"`
+	OpenIssues     int         `json:"open_issues"`
+	Watchers       int         `json:"watchers"`
+	DefaultBranch  string      `json:"default_branch"`
+	TempCloneToken interface{} `json:"temp_clone_token"`
+	Organization   struct {
+		Login             string `json:"login"`
+		ID                int    `json:"id"`
+		NodeID            string `json:"node_id"`
+		AvatarURL         string `json:"avatar_url"`
+		GravatarID        string `json:"gravatar_id"`
+		URL               string `json:"url"`
+		HTMLURL           string `json:"html_url"`
+		FollowersURL      string `json:"followers_url"`
+		FollowingURL      string `json:"following_url"`
+		GistsURL          string `json:"gists_url"`
+		StarredURL        string `json:"starred_url"`
+		SubscriptionsURL  string `json:"subscriptions_url"`
+		OrganizationsURL  string `json:"organizations_url"`
+		ReposURL          string `json:"repos_url"`
+		EventsURL         string `json:"events_url"`
+		ReceivedEventsURL string `json:"received_events_url"`
+		Type              string `json:"type"`
+		SiteAdmin         bool   `json:"site_admin"`
+	} `json:"organization"`
+	NetworkCount     int `json:"network_count"`
+	SubscribersCount int `json:"subscribers_count"`
+}

--- a/github/install.go
+++ b/github/install.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/dlclark/regexp2"
 	"github.com/packwiz/packwiz/core"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -120,7 +121,7 @@ func getLatestRelease(slug string, branch string) (Release, error) {
 }
 
 func installRelease(repo Repo, release Release, regex string, pack core.Pack) error {
-	expr := regexp.MustCompile(regex)
+	expr := regexp2.MustCompile(regex, 0)
 
 	if len(release.Assets) == 0 {
 		return errors.New("release doesn't have any assets attached")
@@ -129,7 +130,8 @@ func installRelease(repo Repo, release Release, regex string, pack core.Pack) er
 	var files []Asset
 
 	for _, v := range release.Assets {
-		if expr.MatchString(v.Name) {
+		bl, _ := expr.MatchString(v.Name)
+		if bl {
 			files = append(files, v)
 		}
 	}

--- a/github/install.go
+++ b/github/install.go
@@ -93,7 +93,12 @@ func fetchMod(slug string) (Mod, error) {
 
 	repoResp, err := http.Get(githubApiUrl + "repos/" + slug)
 
+	if err != nil {
+		return mod, err
+	}
+
 	defer repoResp.Body.Close()
+
 	repoBody, err := ioutil.ReadAll(repoResp.Body)
 	if err != nil {
 		return mod, err
@@ -209,7 +214,7 @@ func installVersion(mod Mod, version ModReleases, pack core.Pack) error {
 		return err
 	}
 
-	hash, error := file.getSha256()
+	hash, error := file.getSha1()
 	if error != nil || hash == "" {
 		return errors.New("file doesn't have a hash")
 	}
@@ -220,7 +225,7 @@ func installVersion(mod Mod, version ModReleases, pack core.Pack) error {
 		Side:     "unknown",
 		Download: core.ModDownload{
 			URL:        file.BrowserDownloadURL,
-			HashFormat: "sha256",
+			HashFormat: "sha1",
 			Hash:       hash,
 		},
 		Update: updateMap,
@@ -336,9 +341,9 @@ type Asset struct {
 	BrowserDownloadURL string    `json:"browser_download_url"`
 }
 
-func (u Asset) getSha256() (string, error) {
+func (u Asset) getSha1() (string, error) {
 	// TODO potentionally cache downloads to speed things up and avoid getting ratelimited by github!
-	mainHasher, err := core.GetHashImpl("sha256")
+	mainHasher, err := core.GetHashImpl("sha1")
 	resp, err := http.Get(u.BrowserDownloadURL)
 	if err != nil {
 		return "", err

--- a/github/install.go
+++ b/github/install.go
@@ -161,7 +161,7 @@ func installRelease(repo Repo, release Release, regex string, pack core.Pack) er
 		Slug:   repo.FullName,
 		Tag:    release.TagName,
 		Branch: release.TargetCommitish, // TODO: if no branch is specified by the user, we shouldn't record it - in order to remain branch-agnostic in getLatestRelease()
-		Regex: regex, // TODO: ditto!
+		Regex:  regex,                   // TODO: ditto!
 	}.ToMap()
 	if err != nil {
 		return err

--- a/github/install.go
+++ b/github/install.go
@@ -43,10 +43,11 @@ var installCmd = &cobra.Command{
 		// The default will match any asset with a name that does *not* end with:
 		// - "-api.jar"
 		// - "-dev.jar"
+		// - "-dev-preshadow.jar"
 		// - "-sources.jar"
 		// In most cases, this will only match one asset.
 		// TODO: Hopefully.
-		regex := `^.+(?<!-api|-dev|-sources)\.jar$`
+		regex := `^.+(?<!-api|-dev|-dev-preshadow|-sources)\.jar$`
 
 		// Check if the argument is a valid GitHub repository URL; if so, extract the slug from the URL.
 		// Otherwise, interpret the argument as a slug directly.

--- a/github/install.go
+++ b/github/install.go
@@ -8,19 +8,20 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
-	"time"
 
-	"github.com/mitchellh/mapstructure"
 	"github.com/packwiz/packwiz/core"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
+var GithubRegex = regexp.MustCompile("https?://(?:www\\.)?github\\.com/([^/]+/[^/]+)")
+
 // installCmd represents the install command
 var installCmd = &cobra.Command{
 	Use:     "install [mod]",
-	Short:   "Install a mod from a github URL",
+	Short:   "Install mods from github releases",
 	Aliases: []string{"add", "get"},
 	Args:    cobra.ArbitraryArgs,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -35,22 +36,26 @@ var installCmd = &cobra.Command{
 			fmt.Println("You must specify a mod.")
 			os.Exit(1)
 		}
-		if strings.HasSuffix(args[0], "/") {
-			fmt.Println("Url cant have a leading slash!")
-			os.Exit(1)
-		}
 
-		slug := strings.Replace(args[0], "https://github.com/", "", 1)
+		//Try interpreting the arg as a modId or slug.
+		//Modrinth transparently handles slugs/mod ids in their api; we don't have to detect which one it is.
+		var slug string
 
-		if len(strings.Split(args[0], "/")) == 1 {
+		//Try to see if it's a site, if extract the id/slug from the url.
+		//Otherwise, interpret the arg as a id/slug straight up
+		matches := GithubRegex.FindStringSubmatch(args[0])
+		if matches != nil && len(matches) == 2 {
+			slug = matches[1]
+		} else {
 			slug = args[0]
 		}
 
-		if strings.Contains(slug, "/releases") {
-			slug = strings.Split(slug, "/releases")[0]
-		}
-
 		mod, err := fetchMod(slug)
+
+		if err != nil {
+			fmt.Println("Failed to get the mod ", err)
+			os.Exit(1)
+		}
 
 		installMod(mod, pack)
 	},
@@ -62,80 +67,10 @@ func init() {
 
 const githubApiUrl = "https://api.github.com/"
 
-func fetchMod(slug string) (Mod, error) {
-	var modReleases []ModReleases
-	var mod Mod
-	resp, err := http.Get(githubApiUrl + "repos/" + slug + "/releases")
-	if err != nil {
-		return mod, err
-	}
-
-	if resp.StatusCode == 404 {
-		return mod, fmt.Errorf("mod not found (for URL %v)", githubApiUrl+"repos/"+slug+"/releases")
-	}
-
-	if resp.StatusCode != 200 {
-		return mod, fmt.Errorf("invalid response status %v for URL %v", resp.Status, githubApiUrl+"repos/"+slug+"/releases")
-	}
-
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return mod, err
-	}
-
-	err = json.Unmarshal(body, &modReleases)
-	if err != nil {
-		return mod, err
-	}
-
-	var repoData Repo
-
-	repoResp, err := http.Get(githubApiUrl + "repos/" + slug)
-
-	if err != nil {
-		return mod, err
-	}
-
-	defer repoResp.Body.Close()
-
-	repoBody, err := ioutil.ReadAll(repoResp.Body)
-	if err != nil {
-		return mod, err
-	}
-
-	err = json.Unmarshal(repoBody, &repoData)
-	if err != nil {
-		return mod, err
-	}
-
-	release := modReleases[0]
-
-	mod = Mod{
-		ID:          repoData.Name,
-		Slug:        slug,
-		Team:        repoData.Owner.Login,
-		Title:       repoData.Name,
-		Description: repoData.Description,
-		Published:   repoData.CreatedAt,
-		Updated:     release.CreatedAt,
-		License:     repoData.License,
-		ClientSide:  "unknown",
-		ServerSide:  "unknown",
-		Categories:  repoData.Topics,
-	}
-	if mod.ID == "" {
-		return mod, errors.New("invalid json whilst fetching mod: " + slug)
-	}
-
-	return mod, nil
-
-}
-
 func installMod(mod Mod, pack core.Pack) error {
-	fmt.Printf("Found mod %s: '%s'.\n", mod.Title, mod.Description)
+	fmt.Printf("Found repo %s: '%s'.\n", mod.Slug, mod.Description)
 
-	latestVersion, err := getLatestVersion(mod.Slug, pack, "")
+	latestVersion, err := getLatestVersion(mod.Slug, "")
 	if err != nil {
 		return fmt.Errorf("failed to get latest version: %v", err)
 	}
@@ -146,7 +81,7 @@ func installMod(mod Mod, pack core.Pack) error {
 	return installVersion(mod, latestVersion, pack)
 }
 
-func getLatestVersion(slug string, pack core.Pack, branch string) (ModReleases, error) {
+func getLatestVersion(slug string, branch string) (ModReleases, error) {
 	var modReleases []ModReleases
 	var release ModReleases
 
@@ -206,7 +141,7 @@ func installVersion(mod Mod, version ModReleases, pack core.Pack) error {
 	updateMap := make(map[string]map[string]interface{})
 
 	updateMap["github"], err = ghUpdateData{
-		ModID:            mod.Slug,
+		Slug:             mod.Slug,
 		InstalledVersion: version.TagName,
 		Branch:           version.TargetCommitish,
 	}.ToMap()
@@ -263,232 +198,4 @@ func installVersion(mod Mod, version ModReleases, pack core.Pack) error {
 		return err
 	}
 	return nil
-}
-
-func (u ghUpdateData) ToMap() (map[string]interface{}, error) {
-	newMap := make(map[string]interface{})
-	err := mapstructure.Decode(u, &newMap)
-	return newMap, err
-}
-
-type License struct {
-	Id   string `json:"id"`   //The license id of a mod, retrieved from the licenses get route
-	Name string `json:"name"` //The long for name of a license
-	Url  string `json:"url"`  //The URL to this license
-}
-
-type Mod struct {
-	ID          string `json:"id"`          //The ID of the mod, encoded as a base62 string
-	Slug        string `json:"slug"`        //The slug of a mod, used for vanity URLs
-	Team        string `json:"team"`        //The id of the team that has ownership of this mod
-	Title       string `json:"title"`       //The title or name of the mod
-	Description string `json:"description"` //A short description of the mod
-	// Body        string   `json:"body"`        //A long form description of the mod.
-	// BodyUrl     string   `json:"body_url"`    //DEPRECATED The link to the long description of the mod (Optional)
-	Published string `json:"published"` //The date at which the mod was first published
-	Updated   string `json:"updated"`   //The date at which the mod was updated
-	License   struct {
-		Key    string `json:"key"`
-		Name   string `json:"name"`
-		SpdxID string `json:"spdx_id"`
-		URL    string `json:"url"`
-		NodeID string `json:"node_id"`
-	} `json:"license"`
-	ClientSide string `json:"client_side"` //The support range for the client mod - required, optional, unsupported, or unknown
-	ServerSide string `json:"server_side"` //The support range for the server mod - required, optional, unsupported, or unknown
-	// Downloads  int      `json:"downloads"`   //The total number of downloads the mod has
-	Categories []string `json:"categories"`  //A list of the categories that the mod is in
-	Versions   []string `json:"versions"`    //A list of ids for versions of the mod
-	IconUrl    string   `json:"icon_url"`    //The URL of the icon of the mod (Optional)
-	IssuesUrl  string   `json:"issues_url"`  //An optional link to where to submit bugs or issues with the mod (Optional)
-	SourceUrl  string   `json:"source_url"`  //An optional link to the source code for the mod (Optional)
-	WikiUrl    string   `json:"wiki_url"`    //An optional link to the mod's wiki page or other relevant information (Optional)
-	DiscordUrl string   `json:"discord_url"` //An optional link to the mod's discord (Optional)
-}
-
-type Asset struct {
-	URL      string      `json:"url"`
-	ID       int         `json:"id"`
-	NodeID   string      `json:"node_id"`
-	Name     string      `json:"name"`
-	Label    interface{} `json:"label"`
-	Uploader struct {
-		Login             string `json:"login"`
-		ID                int    `json:"id"`
-		NodeID            string `json:"node_id"`
-		AvatarURL         string `json:"avatar_url"`
-		GravatarID        string `json:"gravatar_id"`
-		URL               string `json:"url"`
-		HTMLURL           string `json:"html_url"`
-		FollowersURL      string `json:"followers_url"`
-		FollowingURL      string `json:"following_url"`
-		GistsURL          string `json:"gists_url"`
-		StarredURL        string `json:"starred_url"`
-		SubscriptionsURL  string `json:"subscriptions_url"`
-		OrganizationsURL  string `json:"organizations_url"`
-		ReposURL          string `json:"repos_url"`
-		EventsURL         string `json:"events_url"`
-		ReceivedEventsURL string `json:"received_events_url"`
-		Type              string `json:"type"`
-		SiteAdmin         bool   `json:"site_admin"`
-	} `json:"uploader"`
-	ContentType        string    `json:"content_type"`
-	State              string    `json:"state"`
-	Size               int       `json:"size"`
-	DownloadCount      int       `json:"download_count"`
-	CreatedAt          time.Time `json:"created_at"`
-	UpdatedAt          time.Time `json:"updated_at"`
-	BrowserDownloadURL string    `json:"browser_download_url"`
-}
-
-func (u Asset) getSha1() (string, error) {
-	// TODO potentionally cache downloads to speed things up and avoid getting ratelimited by github!
-	mainHasher, err := core.GetHashImpl("sha1")
-	resp, err := http.Get(u.BrowserDownloadURL)
-	if err != nil {
-		return "", err
-	}
-	if resp.StatusCode == 404 {
-		return "", fmt.Errorf("Asset not found")
-	}
-
-	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("Invalid response code: %d", resp.StatusCode)
-	}
-
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	mainHasher.Write(body)
-
-	hash := mainHasher.Sum(nil)
-
-	return mainHasher.HashToString(hash), nil
-}
-
-type Repo struct {
-	ID       int    `json:"id"`
-	NodeID   string `json:"node_id"`
-	Name     string `json:"name"`
-	FullName string `json:"full_name"`
-	Private  bool   `json:"private"`
-	Owner    struct {
-		Login             string `json:"login"`
-		ID                int    `json:"id"`
-		NodeID            string `json:"node_id"`
-		AvatarURL         string `json:"avatar_url"`
-		GravatarID        string `json:"gravatar_id"`
-		URL               string `json:"url"`
-		HTMLURL           string `json:"html_url"`
-		FollowersURL      string `json:"followers_url"`
-		FollowingURL      string `json:"following_url"`
-		GistsURL          string `json:"gists_url"`
-		StarredURL        string `json:"starred_url"`
-		SubscriptionsURL  string `json:"subscriptions_url"`
-		OrganizationsURL  string `json:"organizations_url"`
-		ReposURL          string `json:"repos_url"`
-		EventsURL         string `json:"events_url"`
-		ReceivedEventsURL string `json:"received_events_url"`
-		Type              string `json:"type"`
-		SiteAdmin         bool   `json:"site_admin"`
-	} `json:"owner"`
-	HTMLURL          string      `json:"html_url"`
-	Description      string      `json:"description"`
-	Fork             bool        `json:"fork"`
-	URL              string      `json:"url"`
-	ForksURL         string      `json:"forks_url"`
-	KeysURL          string      `json:"keys_url"`
-	CollaboratorsURL string      `json:"collaborators_url"`
-	TeamsURL         string      `json:"teams_url"`
-	HooksURL         string      `json:"hooks_url"`
-	IssueEventsURL   string      `json:"issue_events_url"`
-	EventsURL        string      `json:"events_url"`
-	AssigneesURL     string      `json:"assignees_url"`
-	BranchesURL      string      `json:"branches_url"`
-	TagsURL          string      `json:"tags_url"`
-	BlobsURL         string      `json:"blobs_url"`
-	GitTagsURL       string      `json:"git_tags_url"`
-	GitRefsURL       string      `json:"git_refs_url"`
-	TreesURL         string      `json:"trees_url"`
-	StatusesURL      string      `json:"statuses_url"`
-	LanguagesURL     string      `json:"languages_url"`
-	StargazersURL    string      `json:"stargazers_url"`
-	ContributorsURL  string      `json:"contributors_url"`
-	SubscribersURL   string      `json:"subscribers_url"`
-	SubscriptionURL  string      `json:"subscription_url"`
-	CommitsURL       string      `json:"commits_url"`
-	GitCommitsURL    string      `json:"git_commits_url"`
-	CommentsURL      string      `json:"comments_url"`
-	IssueCommentURL  string      `json:"issue_comment_url"`
-	ContentsURL      string      `json:"contents_url"`
-	CompareURL       string      `json:"compare_url"`
-	MergesURL        string      `json:"merges_url"`
-	ArchiveURL       string      `json:"archive_url"`
-	DownloadsURL     string      `json:"downloads_url"`
-	IssuesURL        string      `json:"issues_url"`
-	PullsURL         string      `json:"pulls_url"`
-	MilestonesURL    string      `json:"milestones_url"`
-	NotificationsURL string      `json:"notifications_url"`
-	LabelsURL        string      `json:"labels_url"`
-	ReleasesURL      string      `json:"releases_url"`
-	DeploymentsURL   string      `json:"deployments_url"`
-	CreatedAt        string      `json:"created_at"`
-	UpdatedAt        string      `json:"updated_at"`
-	PushedAt         string      `json:"pushed_at"`
-	GitURL           string      `json:"git_url"`
-	SSHURL           string      `json:"ssh_url"`
-	CloneURL         string      `json:"clone_url"`
-	SvnURL           string      `json:"svn_url"`
-	Homepage         string      `json:"homepage"`
-	Size             int         `json:"size"`
-	StargazersCount  int         `json:"stargazers_count"`
-	WatchersCount    int         `json:"watchers_count"`
-	Language         string      `json:"language"`
-	HasIssues        bool        `json:"has_issues"`
-	HasProjects      bool        `json:"has_projects"`
-	HasDownloads     bool        `json:"has_downloads"`
-	HasWiki          bool        `json:"has_wiki"`
-	HasPages         bool        `json:"has_pages"`
-	ForksCount       int         `json:"forks_count"`
-	MirrorURL        interface{} `json:"mirror_url"`
-	Archived         bool        `json:"archived"`
-	Disabled         bool        `json:"disabled"`
-	OpenIssuesCount  int         `json:"open_issues_count"`
-	License          struct {
-		Key    string `json:"key"`
-		Name   string `json:"name"`
-		SpdxID string `json:"spdx_id"`
-		URL    string `json:"url"`
-		NodeID string `json:"node_id"`
-	} `json:"license"`
-	AllowForking   bool        `json:"allow_forking"`
-	IsTemplate     bool        `json:"is_template"`
-	Topics         []string    `json:"topics"`
-	Visibility     string      `json:"visibility"`
-	Forks          int         `json:"forks"`
-	OpenIssues     int         `json:"open_issues"`
-	Watchers       int         `json:"watchers"`
-	DefaultBranch  string      `json:"default_branch"`
-	TempCloneToken interface{} `json:"temp_clone_token"`
-	Organization   struct {
-		Login             string `json:"login"`
-		ID                int    `json:"id"`
-		NodeID            string `json:"node_id"`
-		AvatarURL         string `json:"avatar_url"`
-		GravatarID        string `json:"gravatar_id"`
-		URL               string `json:"url"`
-		HTMLURL           string `json:"html_url"`
-		FollowersURL      string `json:"followers_url"`
-		FollowingURL      string `json:"following_url"`
-		GistsURL          string `json:"gists_url"`
-		StarredURL        string `json:"starred_url"`
-		SubscriptionsURL  string `json:"subscriptions_url"`
-		OrganizationsURL  string `json:"organizations_url"`
-		ReposURL          string `json:"repos_url"`
-		EventsURL         string `json:"events_url"`
-		ReceivedEventsURL string `json:"received_events_url"`
-		Type              string `json:"type"`
-		SiteAdmin         bool   `json:"site_admin"`
-	} `json:"organization"`
-	NetworkCount     int `json:"network_count"`
-	SubscribersCount int `json:"subscribers_count"`
 }

--- a/github/install.go
+++ b/github/install.go
@@ -37,6 +37,7 @@ var installCmd = &cobra.Command{
 
 		// Try interpreting the argument as a slug, or GitHub repository URL.
 		var slug string
+		var branch string
 
 		// Check if the argument is a valid GitHub repository URL; if so, extract the slug from the URL.
 		// Otherwise, interpret the argument as a slug directly.
@@ -54,7 +55,11 @@ var installCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		err = installMod(repo, pack)
+		if branchFlag != "" {
+			branch = branchFlag
+		}
+
+		err = installMod(repo, branch, pack)
 		if err != nil {
 			fmt.Printf("Failed to add project: %s\n", err)
 			os.Exit(1)
@@ -62,12 +67,8 @@ var installCmd = &cobra.Command{
 	},
 }
 
-func init() {
-	githubCmd.AddCommand(installCmd)
-}
-
-func installMod(repo Repo, pack core.Pack) error {
-	latestRelease, err := getLatestRelease(repo.FullName, "")
+func installMod(repo Repo, branch string, pack core.Pack) error {
+	latestRelease, err := getLatestRelease(repo.FullName, branch)
 	if err != nil {
 		return fmt.Errorf("failed to get latest release: %v", err)
 	}
@@ -193,4 +194,11 @@ func installRelease(repo Repo, release Release, pack core.Pack) error {
 	fmt.Printf("Project \"%s\" successfully added! (%s)\n", repo.Name, file.Name)
 	return nil
 }
+
+var branchFlag string
+
+func init() {
+	githubCmd.AddCommand(installCmd)
+
+	installCmd.Flags().StringVar(&branchFlag, "branch", "", "The GitHub repository branch to retrieve releases for")
 }

--- a/github/install.go
+++ b/github/install.go
@@ -29,6 +29,7 @@ var installCmd = &cobra.Command{
 	Args:    cobra.ArbitraryArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		pack, err := core.LoadPack()
+
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
@@ -44,6 +45,14 @@ var installCmd = &cobra.Command{
 		}
 
 		slug := strings.Replace(args[0], "https://github.com/", "", 1)
+
+		if len(strings.Split(args[0], "/")) == 1 {
+			slug = args[0]
+		}
+
+		if strings.Contains(slug, "/releases") {
+			slug = strings.Split(slug, "/releases")[0]
+		}
 
 		mod, err := fetchMod(slug)
 
@@ -197,11 +206,6 @@ func installVersion(mod Mod, version ModReleases, pack core.Pack) error {
 	if err != nil {
 		return err
 	}
-
-	// side := mod.getSide()
-	// if side == "" {
-	// 	return errors.New("version doesn't have a side that's supported. Server: " + mod.ServerSide + " Client: " + mod.ClientSide)
-	// }
 
 	hash, error := file.getSha256()
 	if error != nil || hash == "" {

--- a/github/install.go
+++ b/github/install.go
@@ -85,14 +85,19 @@ func getLatestRelease(slug string, branch string) (Release, error) {
 	if err != nil {
 		return release, err
 	}
+
 	err = json.Unmarshal(body, &releases)
 	if err != nil {
 		return release, err
 	}
-	for _, r := range releases {
-		if r.TargetCommitish == branch {
-			return r, nil
+
+	if branch != "" {
+		for _, r := range releases {
+			if r.TargetCommitish == branch {
+				return r, nil
+			}
 		}
+		return release, fmt.Errorf("failed to find release for branch %v", branch)
 	}
 
 	return releases[0], nil
@@ -113,7 +118,7 @@ func installRelease(repo Repo, release Release, pack core.Pack) error {
 		}
 	}
 
-	//Install the file
+	// Install the file
 	fmt.Printf("Installing %s from release %s\n", file.Name, release.TagName)
 	index, err := pack.LoadIndex()
 	if err != nil {
@@ -125,7 +130,7 @@ func installRelease(repo Repo, release Release, pack core.Pack) error {
 	updateMap["github"], err = ghUpdateData{
 		Slug:   repo.FullName,
 		Tag:    release.TagName,
-		Branch: release.TargetCommitish,
+		Branch: release.TargetCommitish, // TODO: if no branch is specified by the user, we shouldn't record it - in order to remain branch-agnostic in getLatestRelease()
 	}.ToMap()
 	if err != nil {
 		return err

--- a/github/request.go
+++ b/github/request.go
@@ -3,6 +3,8 @@ package github
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/packwiz/packwiz/core"
 )
 
 const ghApiServer = "api.github.com"
@@ -13,21 +15,40 @@ type ghApiClient struct {
 
 var ghDefaultClient = ghApiClient{&http.Client{}}
 
-func (c *ghApiClient) makeGet(slug string) (*http.Response, error) {
-	req, err := http.NewRequest("GET", "https://" + ghApiServer + "/repos/" + slug + "/releases", nil)
+func (c *ghApiClient) makeGet(url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
+	req.Header.Set("User-Agent", core.UserAgent)
 	req.Header.Set("Accept", "application/vnd.github+json")
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
-
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("invalid response status: %v", resp.Status)
 	}
+
+	return resp, nil
+}
+
+func (c *ghApiClient) getRepo(slug string) (*http.Response, error) {
+	resp, err := c.makeGet("https://" + ghApiServer + "/repos/" + slug)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+func (c *ghApiClient) getReleases(slug string) (*http.Response, error) {
+	resp, err := c.getRepo(slug + "/releases")
+	if err != nil {
+		return resp, err
+	}
+
 	return resp, nil
 }

--- a/github/request.go
+++ b/github/request.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-// TODO: allow setting github api key via env variable
 const ghApiServer = "api.github.com"
 
 type ghApiClient struct {

--- a/github/request.go
+++ b/github/request.go
@@ -3,9 +3,9 @@ package github
 import (
 	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/packwiz/packwiz/core"
+	"github.com/spf13/viper"
 )
 
 // TODO: allow setting github api key via env variable
@@ -18,7 +18,7 @@ type ghApiClient struct {
 var ghDefaultClient = ghApiClient{&http.Client{}}
 
 func (c *ghApiClient) makeGet(url string) (*http.Response, error) {
-	ghApiToken := os.Getenv("GH_API_TOKEN")
+	ghApiToken := viper.GetString("github.token")
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/github/request.go
+++ b/github/request.go
@@ -7,6 +7,7 @@ import (
 	"github.com/packwiz/packwiz/core"
 )
 
+// TODO: allow setting github api key via env variable
 const ghApiServer = "api.github.com"
 
 type ghApiClient struct {

--- a/github/request.go
+++ b/github/request.go
@@ -3,6 +3,7 @@ package github
 import (
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/packwiz/packwiz/core"
 )
@@ -17,6 +18,8 @@ type ghApiClient struct {
 var ghDefaultClient = ghApiClient{&http.Client{}}
 
 func (c *ghApiClient) makeGet(url string) (*http.Response, error) {
+	ghApiToken := os.Getenv("GH_API_TOKEN")
+
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
@@ -24,6 +27,9 @@ func (c *ghApiClient) makeGet(url string) (*http.Response, error) {
 
 	req.Header.Set("User-Agent", core.UserAgent)
 	req.Header.Set("Accept", "application/vnd.github+json")
+	if ghApiToken != "" {
+		req.Header.Set("Authorization", "Bearer " + ghApiToken)
+	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/github/request.go
+++ b/github/request.go
@@ -37,9 +37,15 @@ func (c *ghApiClient) makeGet(url string) (*http.Response, error) {
 		return nil, err
 	}
 
-	ratelimit, err := strconv.Atoi(resp.Header.Get("x-ratelimit-remaining"))
-	if err != nil {
-		return nil, err
+	// TODO: there is likely a better way to do this
+	ratelimit := 999
+
+	ratelimit_header := resp.Header.Get("x-ratelimit-remaining")
+	if ratelimit_header != "" {
+		ratelimit, err = strconv.Atoi(ratelimit_header)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if resp.StatusCode == 403 && ratelimit == 0 {

--- a/github/request.go
+++ b/github/request.go
@@ -28,7 +28,7 @@ func (c *ghApiClient) makeGet(url string) (*http.Response, error) {
 	req.Header.Set("User-Agent", core.UserAgent)
 	req.Header.Set("Accept", "application/vnd.github+json")
 	if ghApiToken != "" {
-		req.Header.Set("Authorization", "Bearer " + ghApiToken)
+		req.Header.Set("Authorization", "Bearer "+ghApiToken)
 	}
 
 	resp, err := c.httpClient.Do(req)

--- a/github/request.go
+++ b/github/request.go
@@ -1,0 +1,33 @@
+package github
+
+import (
+	"fmt"
+	"net/http"
+)
+
+const ghApiServer = "api.github.com"
+
+type ghApiClient struct {
+	httpClient *http.Client
+}
+
+var ghDefaultClient = ghApiClient{&http.Client{}}
+
+func (c *ghApiClient) makeGet(slug string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", "https://" + ghApiServer + "/repos/" + slug + "/releases", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("invalid response status: %v", resp.Status)
+	}
+	return resp, nil
+}

--- a/github/updater.go
+++ b/github/updater.go
@@ -1,0 +1,102 @@
+package github
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/packwiz/packwiz/core"
+)
+
+type ghUpdateData struct {
+	ModID            string `mapstructure:"mod-id"` // The slug of the repo but named modId for consistency reasons
+	InstalledVersion string `mapstructure:"version"`
+}
+
+type ghUpdater struct{}
+
+func (u ghUpdater) ParseUpdate(updateUnparsed map[string]interface{}) (interface{}, error) {
+	var updateData ghUpdateData
+	err := mapstructure.Decode(updateUnparsed, &updateData)
+	return updateData, err
+}
+
+type cachedStateStore struct {
+	ModID   string
+	Version ModReleases
+}
+
+func (u ghUpdater) CheckUpdate(mods []core.Mod, mcVersion string, pack core.Pack) ([]core.UpdateCheck, error) {
+	results := make([]core.UpdateCheck, len(mods))
+
+	for i, mod := range mods {
+		rawData, ok := mod.GetParsedUpdateData("modrinth")
+		if !ok {
+			results[i] = core.UpdateCheck{Error: errors.New("couldn't parse mod data")}
+			continue
+		}
+
+		data := rawData.(ghUpdateData)
+
+		newVersion, err := getLatestVersion(data.ModID, pack)
+		if err != nil {
+			results[i] = core.UpdateCheck{Error: fmt.Errorf("failed to get latest version: %v", err)}
+			continue
+		}
+
+		// if newVersion.ID == "" { //There is no version available for this minecraft version or loader.
+		// 	results[i] = core.UpdateCheck{UpdateAvailable: false}
+		// 	continue
+		// }
+
+		if newVersion.TagName == data.InstalledVersion { //The latest version from the site is the same as the installed one
+			results[i] = core.UpdateCheck{UpdateAvailable: false}
+			continue
+		}
+
+		if len(newVersion.Assets) == 0 {
+			results[i] = core.UpdateCheck{Error: errors.New("new version doesn't have any files")}
+			continue
+		}
+
+		newFilename := newVersion.Assets[0].Name
+
+		results[i] = core.UpdateCheck{
+			UpdateAvailable: true,
+			UpdateString:    mod.FileName + " -> " + newFilename,
+			CachedState:     cachedStateStore{data.ModID, newVersion},
+		}
+	}
+
+	return results, nil
+}
+
+func (u ghUpdater) DoUpdate(mods []*core.Mod, cachedState []interface{}) error {
+	for i, mod := range mods {
+		modState := cachedState[i].(cachedStateStore)
+		var version = modState.Version
+
+		var file = version.Assets[0]
+		for _, v := range version.Assets {
+			if strings.HasSuffix(v.Name, ".jar") {
+				file = v
+			}
+		}
+
+		hash, error := file.getSha256()
+		if error != nil || hash == "" {
+			return errors.New("file doesn't have a hash")
+		}
+
+		mod.FileName = file.Name
+		mod.Download = core.ModDownload{
+			URL:        file.BrowserDownloadURL,
+			HashFormat: "sha256",
+			Hash:       hash,
+		}
+		mod.Update["modrinth"]["version"] = version.ID
+	}
+
+	return nil
+}

--- a/github/updater.go
+++ b/github/updater.go
@@ -45,11 +45,6 @@ func (u ghUpdater) CheckUpdate(mods []core.Mod, mcVersion string, pack core.Pack
 			continue
 		}
 
-		// if newVersion.ID == "" { //There is no version available for this minecraft version or loader.
-		// 	results[i] = core.UpdateCheck{UpdateAvailable: false}
-		// 	continue
-		// }
-
 		if newVersion.TagName == data.InstalledVersion { //The latest version from the site is the same as the installed one
 			results[i] = core.UpdateCheck{UpdateAvailable: false}
 			continue

--- a/github/updater.go
+++ b/github/updater.go
@@ -3,9 +3,9 @@ package github
 import (
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
 
+	"github.com/dlclark/regexp2"
 	"github.com/mitchellh/mapstructure"
 	"github.com/packwiz/packwiz/core"
 )
@@ -53,7 +53,7 @@ func (u ghUpdater) CheckUpdate(mods []*core.Mod, pack core.Pack) ([]core.UpdateC
 			continue
 		}
 
-		expr := regexp.MustCompile(data.Regex)
+		expr := regexp2.MustCompile(data.Regex, 0)
 
 		if len(newRelease.Assets) == 0 {
 			results[i] = core.UpdateCheck{Error: errors.New("new release doesn't have any assets")}
@@ -63,7 +63,8 @@ func (u ghUpdater) CheckUpdate(mods []*core.Mod, pack core.Pack) ([]core.UpdateC
 		var newFiles []Asset
 
 		for _, v := range newRelease.Assets {
-			if expr.MatchString(v.Name) {
+			bl, _ := expr.MatchString(v.Name)
+			if bl {
 				newFiles = append(newFiles, v)
 			}
 		}

--- a/github/updater.go
+++ b/github/updater.go
@@ -80,7 +80,7 @@ func (u ghUpdater) DoUpdate(mods []*core.Mod, cachedState []interface{}) error {
 			}
 		}
 
-		hash, error := file.getSha256()
+		hash, error := file.getSha1()
 		if error != nil || hash == "" {
 			return errors.New("file doesn't have a hash")
 		}
@@ -88,7 +88,7 @@ func (u ghUpdater) DoUpdate(mods []*core.Mod, cachedState []interface{}) error {
 		mod.FileName = file.Name
 		mod.Download = core.ModDownload{
 			URL:        file.BrowserDownloadURL,
-			HashFormat: "sha256",
+			HashFormat: "sha1",
 			Hash:       hash,
 		}
 		mod.Update["github"]["version"] = version.ID

--- a/github/updater.go
+++ b/github/updater.go
@@ -10,7 +10,7 @@ import (
 )
 
 type ghUpdateData struct {
-	ModID            string `mapstructure:"mod-id"` // The slug of the repo but named modId for consistency reasons
+	Slug             string `mapstructure:"slug"`
 	InstalledVersion string `mapstructure:"version"`
 	Branch           string `mapstructure:"branch"`
 }
@@ -40,7 +40,7 @@ func (u ghUpdater) CheckUpdate(mods []core.Mod, mcVersion string, pack core.Pack
 
 		data := rawData.(ghUpdateData)
 
-		newVersion, err := getLatestVersion(data.ModID, pack, data.Branch)
+		newVersion, err := getLatestVersion(data.Slug, data.Branch)
 		if err != nil {
 			results[i] = core.UpdateCheck{Error: fmt.Errorf("failed to get latest version: %v", err)}
 			continue
@@ -61,7 +61,7 @@ func (u ghUpdater) CheckUpdate(mods []core.Mod, mcVersion string, pack core.Pack
 		results[i] = core.UpdateCheck{
 			UpdateAvailable: true,
 			UpdateString:    mod.FileName + " -> " + newFilename,
-			CachedState:     cachedStateStore{data.ModID, newVersion},
+			CachedState:     cachedStateStore{data.Slug, newVersion},
 		}
 	}
 
@@ -91,7 +91,7 @@ func (u ghUpdater) DoUpdate(mods []*core.Mod, cachedState []interface{}) error {
 			HashFormat: "sha1",
 			Hash:       hash,
 		}
-		mod.Update["github"]["version"] = version.ID
+		mod.Update["github"]["version"] = version.TagName
 	}
 
 	return nil

--- a/github/updater.go
+++ b/github/updater.go
@@ -68,6 +68,11 @@ func (u ghUpdater) CheckUpdate(mods []*core.Mod, pack core.Pack) ([]core.UpdateC
 			}
 		}
 
+		if len(newFiles) == 0 {
+			results[i] = core.UpdateCheck{Error: errors.New("release doesn't have any assets matching regex")}
+			continue
+		}
+
 		if len(newFiles) > 1 {
 			// TODO: also print file names
 			results[i] = core.UpdateCheck{Error: errors.New("release has more than one asset matching regex")}

--- a/github/updater.go
+++ b/github/updater.go
@@ -12,6 +12,7 @@ import (
 type ghUpdateData struct {
 	ModID            string `mapstructure:"mod-id"` // The slug of the repo but named modId for consistency reasons
 	InstalledVersion string `mapstructure:"version"`
+	Branch           string `mapstructure:"branch"`
 }
 
 type ghUpdater struct{}
@@ -31,7 +32,7 @@ func (u ghUpdater) CheckUpdate(mods []core.Mod, mcVersion string, pack core.Pack
 	results := make([]core.UpdateCheck, len(mods))
 
 	for i, mod := range mods {
-		rawData, ok := mod.GetParsedUpdateData("modrinth")
+		rawData, ok := mod.GetParsedUpdateData("github")
 		if !ok {
 			results[i] = core.UpdateCheck{Error: errors.New("couldn't parse mod data")}
 			continue
@@ -39,7 +40,7 @@ func (u ghUpdater) CheckUpdate(mods []core.Mod, mcVersion string, pack core.Pack
 
 		data := rawData.(ghUpdateData)
 
-		newVersion, err := getLatestVersion(data.ModID, pack)
+		newVersion, err := getLatestVersion(data.ModID, pack, data.Branch)
 		if err != nil {
 			results[i] = core.UpdateCheck{Error: fmt.Errorf("failed to get latest version: %v", err)}
 			continue
@@ -90,7 +91,7 @@ func (u ghUpdater) DoUpdate(mods []*core.Mod, cachedState []interface{}) error {
 			HashFormat: "sha256",
 			Hash:       hash,
 		}
-		mod.Update["modrinth"]["version"] = version.ID
+		mod.Update["github"]["version"] = version.ID
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/aviddiviner/go-murmur v0.0.0-20150519214947-b9740d71e571
 	github.com/daviddengcn/go-colortext v1.0.0 // indirect
+	github.com/dlclark/regexp2 v1.11.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/igorsobreira/titlecase v0.0.0-20140109233139-4156b5b858ac
 	github.com/kylelemons/godebug v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/daviddengcn/go-colortext v1.0.0 h1:ANqDyC0ys6qCSvuEK7l3g5RaehL/Xck9EX8ATG8oKsE=
 github.com/daviddengcn/go-colortext v1.0.0/go.mod h1:zDqEI5NVUop5QPpVJUxE9UO10hRnmkD5G4Pmri9+m4c=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	// Modules of packwiz
 	"github.com/packwiz/packwiz/cmd"
 	_ "github.com/packwiz/packwiz/curseforge"
+	_ "github.com/packwiz/packwiz/github"
 	_ "github.com/packwiz/packwiz/migrate"
 	_ "github.com/packwiz/packwiz/modrinth"
 	_ "github.com/packwiz/packwiz/settings"


### PR DESCRIPTION
This PR adds support for installing and updating mods / projects from GitHub Releases. It is mostly a continuation of #136.

Things left to do:
- [x] Allow user to specify a GitHub API key (as an environment variable?) (to avoid rate limiting)
- [x] Allow user to specify a branch to retrieve releases for *during initial install* (via command line)
- [x] Allow user to select which asset to download from a release (+ some way to automatically select the same asset during updates?)
- [ ] [Pagination of releases??](https://github.com/packwiz/packwiz/pull/136#discussion_r898490708) (depends on API key feature above)

Closes #30