### PR TITLE
Modlist optional filename

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -3,9 +3,11 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/packwiz/packwiz/core"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // listCmd represents the list command
@@ -36,13 +38,26 @@ var listCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		sort.Slice(mods, func(i, j int) bool {
+			return mods[i].Name < mods[j].Name
+		})
+
 		// Print mods
-		for _, mod := range mods {
-			fmt.Println(mod.Name)
+		if viper.GetBool("list.version") {
+			for _, mod := range mods {
+				fmt.Printf("%s\t[%s]\n", mod.Name, mod.FileName)
+			}
+		} else {
+			for _, mod := range mods {
+				fmt.Println(mod.Name)
+			}
 		}
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(listCmd)
+
+	listCmd.Flags().BoolP("version", "v", false, "Print name and version")
+	_ = viper.BindPFlag("list.version", listCmd.Flags().Lookup("version"))
 }


### PR DESCRIPTION
Changed modlist to use filename instead of Friendlyname for Curseforge and Versionnumber for Modrinth like suggested in #239