### PR TITLE
Prefer SHA-512 for Modrinth, add rehash command

### DIFF
--- a/cmd/rehash.go
+++ b/cmd/rehash.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/packwiz/packwiz/core"
+	"github.com/spf13/cobra"
+)
+
+// rehashCmd represents the rehash command
+var rehashCmd = &cobra.Command{
+	Use:   "rehash",
+	Short: "Migrate all hashes to a specific function",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+
+		// Load pack
+		pack, err := core.LoadPack()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		// Load index
+		index, err := pack.LoadIndex()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		// Load mods
+		mods, err := index.LoadAllMods()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		
+		session, err := core.CreateDownloadSession(mods, []string{args[0]})
+		if err != nil {
+			fmt.Printf("Error retrieving external files: %v\n", err)
+			os.Exit(1)
+		}
+		for dl := range session.StartDownloads() {
+			if dl.Error != nil {
+				fmt.Printf("Error retrieving %s: %v\n", dl.Mod.Name, dl.Error);
+			}
+			dl.Mod.Download.HashFormat = args[0]
+			dl.Mod.Download.Hash = dl.Hashes[args[0]]
+			_, _, err := dl.Mod.Write()
+			if err != nil {
+				fmt.Printf("Error saving mod %s: %v\n", dl.Mod.Name, err)
+				os.Exit(1)
+			}
+			// TODO pass the hash to index instead of recomputing from scratch
+		}
+		
+		err = index.Refresh()
+		if err != nil {
+			fmt.Printf("Error refreshing index: %v\n", err)
+			os.Exit(1)
+		}
+		
+		err = index.Write()
+		if err != nil {
+			fmt.Printf("Error writing index: %v\n", err)
+			os.Exit(1)
+		}
+		
+		err = pack.UpdateIndexHash()
+		if err != nil {
+			fmt.Printf("Error updating index hash: %v\n", err)
+			os.Exit(1)
+		}
+		
+		err = pack.Write()
+		if err != nil {
+			fmt.Printf("Error writing pack: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(rehashCmd)
+}

--- a/cmd/rehash.go
+++ b/cmd/rehash.go
@@ -35,7 +35,7 @@ var rehashCmd = &cobra.Command{
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		
+
 		session, err := core.CreateDownloadSession(mods, []string{args[0]})
 		if err != nil {
 			fmt.Printf("Error retrieving external files: %v\n", err)
@@ -43,7 +43,7 @@ var rehashCmd = &cobra.Command{
 		}
 		for dl := range session.StartDownloads() {
 			if dl.Error != nil {
-				fmt.Printf("Error retrieving %s: %v\n", dl.Mod.Name, dl.Error);
+				fmt.Printf("Error retrieving %s: %v\n", dl.Mod.Name, dl.Error)
 			}
 			dl.Mod.Download.HashFormat = args[0]
 			dl.Mod.Download.Hash = dl.Hashes[args[0]]
@@ -54,25 +54,25 @@ var rehashCmd = &cobra.Command{
 			}
 			// TODO pass the hash to index instead of recomputing from scratch
 		}
-		
+
 		err = index.Refresh()
 		if err != nil {
 			fmt.Printf("Error refreshing index: %v\n", err)
 			os.Exit(1)
 		}
-		
+
 		err = index.Write()
 		if err != nil {
 			fmt.Printf("Error writing index: %v\n", err)
 			os.Exit(1)
 		}
-		
+
 		err = pack.UpdateIndexHash()
 		if err != nil {
 			fmt.Printf("Error updating index hash: %v\n", err)
 			os.Exit(1)
 		}
-		
+
 		err = pack.Write()
 		if err != nil {
 			fmt.Printf("Error writing pack: %v\n", err)

--- a/cmd/rehash.go
+++ b/cmd/rehash.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/packwiz/packwiz/core"
 	"github.com/spf13/cobra"
+	"golang.org/x/exp/slices"
 )
 
 // rehashCmd represents the rehash command
@@ -33,6 +34,11 @@ var rehashCmd = &cobra.Command{
 		mods, err := index.LoadAllMods()
 		if err != nil {
 			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		if !slices.Contains([]string{"sha1", "sha512", "sha256"}, args[0]) {
+			fmt.Printf("Hash format '%s' is not supported\n", args[0])
 			os.Exit(1)
 		}
 

--- a/cmd/rehash.go
+++ b/cmd/rehash.go
@@ -50,13 +50,14 @@ var rehashCmd = &cobra.Command{
 		for dl := range session.StartDownloads() {
 			if dl.Error != nil {
 				fmt.Printf("Error retrieving %s: %v\n", dl.Mod.Name, dl.Error)
-			}
-			dl.Mod.Download.HashFormat = args[0]
-			dl.Mod.Download.Hash = dl.Hashes[args[0]]
-			_, _, err := dl.Mod.Write()
-			if err != nil {
-				fmt.Printf("Error saving mod %s: %v\n", dl.Mod.Name, err)
-				os.Exit(1)
+			} else {
+				dl.Mod.Download.HashFormat = args[0]
+				dl.Mod.Download.Hash = dl.Hashes[args[0]]
+				_, _, err := dl.Mod.Write()
+				if err != nil {
+					fmt.Printf("Error saving mod %s: %v\n", dl.Mod.Name, err)
+					os.Exit(1)
+				}
 			}
 			// TODO pass the hash to index instead of recomputing from scratch
 		}

--- a/modrinth/modrinth.go
+++ b/modrinth/modrinth.go
@@ -361,18 +361,19 @@ func shouldDownloadOnSide(side string) bool {
 }
 
 func getBestHash(v *modrinthApi.File) (string, string) {
-	// Try preferred hashes first; SHA1 is first as it is required for Modrinth pack exporting
-	val, exists := v.Hashes["sha1"]
-	if exists {
-		return "sha1", val
-	}
-	val, exists = v.Hashes["sha512"]
+	// Try preferred hashes first; SHA1 is required for Modrinth pack exporting, but
+	// so is SHA512, so we can't win with the current one-hash format
+	val, exists := v.Hashes["sha512"]
 	if exists {
 		return "sha512", val
 	}
 	val, exists = v.Hashes["sha256"]
 	if exists {
 		return "sha256", val
+	}
+	val, exists = v.Hashes["sha1"]
+	if exists {
+		return "sha1", val
 	}
 	val, exists = v.Hashes["murmur2"] // (not defined in Modrinth pack spec, use with caution)
 	if exists {


### PR DESCRIPTION
*Code quality likely sucks on this, I've never written Go before.*

As part of preparing unsup for manifest signing, I was particularly bothered by packwiz's insistence on SHA-1 once again. It seems the only reason it does so for Modrinth files is that a prior version of the mrpack format only used SHA-1, but it now (as of a year ago, going by Packwiz commits) requires both SHA-512 and SHA-1, so the packwiz Modrinth export is screwed either way with the existing single-hash system. As such, there's no good reason to use a broken hash function when the SHA-512 hashes are just *right there*.

I added the rehash command to [port over my existing modpack](https://git.sleeping.town/Rewind/Upsilon/commit/262ee220d3d400b5f07ec6306d517c6caa248b95) that has URLs from before 6ab823508659cf5fb2a67fc029cb981131eb80a8, it's kitbashed from existing source and probably sucks. I also probably missed at least one error return value, and it could use some form of output instead of being totally silent. I've included it as it may additionally be useful for others with a pack that has a bunch of bad hash functions in it already.

I didn't initially intend to PR this, but I supposed I should in case you're interested in these changes and they don't require *too* egregious rewriting.

Something I also would like to fix is the fact CurseForge files will use SHA-1, *MD5*, or **Murmur2** for validation — Packwiz really should verify that, then compute its own hash. But I'm unsure if the Curse commands will actually download the pointed-to file as-is, or if it just trusts the hash returned by the API. *Ideally*, Curse would stop using broken and non-cryptographic hash functions, but… yeah. Curse.