### PR TITLE
Fix outputting `vendorSha256` to `nix/vendor-sha256`

### DIFF
--- a/nix/prefetcher.nix
+++ b/nix/prefetcher.nix
@@ -3,7 +3,13 @@
   pkgs ? import <nixpkgs> {},
 }:
 pkgs.callPackage (import ./.) {
-  buildGoModule = pkgs.buildGo118Module;
+  ## Keeping `buildGoModule` commented out in case it's needed in the future.
+  ## As of writing, `buildGo121Module` is currently used as the default for
+  ## `buildGoModule` in nixpkgs. `buildGo118Module` seems deprecated and
+  ## entirely removed from nixpkgs, so manually setting that is likely to cause
+  ## issues in the future.
+
+  # buildGoModule = pkgs.buildGo118Module;
   vendorSha256 = sha256;
 }
 // {

--- a/nix/vendor-sha256
+++ b/nix/vendor-sha256
@@ -1,0 +1,1 @@
+sha256-yL5pWbVqf6mEpgYsItLnv8nwSmoMP+SE0rX/s7u2vCg=


### PR DESCRIPTION
This should fix https://github.com/packwiz/packwiz/issues/259 as this should stop GitHub Actions outputting an empty `vendorSha256`, due to `pkgs.buildGo118Module` being seemingly deprecated and entirely removed from [Nixpkgs](https://github.com/NixOS/nixpkgs/).

For testing, I ran `$ nix run nixpkgs#nix-prefetch ./nix/prefetcher.nix | tee ./nix/vendor-sha256` [(like GitHub Actions does)](https://github.com/packwiz/packwiz/blob/main/.github/workflows/nix.yml#L22-L25), which succeeded at returning the `vendorSha256` to stdout and to `nix/vendor-sha256`.

During testing I got a deprecation warning for `vendorSha256`, and that `vendorHash` should be used instead. I'll try to open a separate PR for that specifically though.

As mentioned in the notes that I included in `nix/prefetcher.nix`, which I'm open to removing should that be requested, I commented out the explicitly set `buildGoModule = pkgs.buildGo118Module;`. That fixes the current issue that this PR sets out to fix, and also means that `pkgs.buildGo121Module` will currently be used instead as that's currently what `Nixpkgs` has set upstream... I think. This likely will require more testing.

Example of currently expected output from that `nix run` command:
```bash
$  nix run nixpkgs#nix-prefetch ./nix/prefetcher.nix | tee ./nix/vendor-sha256
trace: warning: `vendorSha256` is deprecated. Use `vendorHash` instead
trace: warning: `vendorSha256` is deprecated. Use `vendorHash` instead
trace: warning: `vendorSha256` is deprecated. Use `vendorHash` instead
trace: warning: `vendorSha256` is deprecated. Use `vendorHash` instead
The fetcher will be called as follows:
> import /home/whovian/Downloads/nixOS/packwiz_fix-nix/nix/prefetcher.nix {
>   sha256 = "sha256:0000000000000000000000000000000000000000000000000000";
> }

sha256-yL5pWbVqf6mEpgYsItLnv8nwSmoMP+SE0rX/s7u2vCg=
```