### PR TITLE
Update version of `buildGoModule` used in `flake.nix`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689444953,
-        "narHash": "sha256-0o56bfb2LC38wrinPdCGLDScd77LVcr7CrH1zK7qvDg=",
+        "lastModified": 1703013332,
+        "narHash": "sha256-+tFNwMvlXLbJZXiMHqYq77z/RfmpfpiI3yjL6o/Zo9M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8acef304efe70152463a6399f73e636bcc363813",
+        "rev": "54aac082a4d9bb5bbc5c4e899603abfb76a3f6d6",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,8 @@
           version = substring 0 8 self.rev or "dirty";
           vendorSha256 = readFile ./nix/vendor-sha256;
           buildGoModule = pkgs.buildGoModule;
+            # As of writing, `pkgs.buildGoModule` is aliased to
+            # `pkgs.buildGo121Module` in Nixpkgs.
         };
         # Build packwiz by default when no package name is specified
         default = packwiz;

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
   outputs = {
     self,

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
         packwiz = pkgs.callPackage ./nix {
           version = substring 0 8 self.rev or "dirty";
           vendorSha256 = readFile ./nix/vendor-sha256;
-          buildGoModule = pkgs.buildGo119Module;
+          buildGoModule = pkgs.buildGoModule;
         };
         # Build packwiz by default when no package name is specified
         default = packwiz;

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,7 @@
 {
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # This maps to https://github.com/NixOS/nixpkgs/tree/nixos-unstable
+    # The `url` option is the pattern of `github:USER_OR_ORG/REPO/BRANCH`
 
   outputs = {
     self,

--- a/nix/prefetcher.nix
+++ b/nix/prefetcher.nix
@@ -3,13 +3,12 @@
   pkgs ? import <nixpkgs> {},
 }:
 pkgs.callPackage (import ./.) {
-  ## Keeping `buildGoModule` commented out in case it's needed in the future.
-  ## As of writing, `buildGo121Module` is currently used as the default for
-  ## `buildGoModule` in nixpkgs. `buildGo118Module` seems deprecated and
-  ## entirely removed from nixpkgs, so manually setting that is likely to cause
-  ## issues in the future.
 
-  # buildGoModule = pkgs.buildGo118Module;
+  buildGoModule = pkgs.buildGoModule;
+    ## As of writing, `pkgs.buildGoModule` is aliased to
+    ## `pkgs.buildGo121Module` in Nixpkgs.
+    ## `buildGoModule` is set as `pkgs.buildGoModule` to try and work around
+    ## `vendorHash` issues in the future.
   vendorSha256 = sha256;
 }
 // {


### PR DESCRIPTION
Following on from #266, this should update the version of `buildGoModule` used to the version of `pkgs.buildGoModule` [that's in the repo's `flake.nix`.](https://github.com/packwiz/packwiz/blob/0c8beeac2fe7a771bd1ddae81d6737af470599de/flake.lock#L4-L11)

-----------

I'm also tempted to add some notes to the [`flake.nix`](https://github.com/packwiz/packwiz/blob/0c8beeac2fe7a771bd1ddae81d6737af470599de/flake.nix#L35), and update the notes in [`nix/prefetcher.nix`](https://github.com/packwiz/packwiz/blob/0c8beeac2fe7a771bd1ddae81d6737af470599de/nix/prefetcher.nix#L6-L13) to reflect this PR's change.

Specifically for [`nix/prefetcher.nix`](https://github.com/packwiz/packwiz/blob/0c8beeac2fe7a771bd1ddae81d6737af470599de/nix/prefetcher.nix#L7), I made a small error and mentioned the incorrect version of `pkgs.buildGoModule` that would be used... With the version of Nixpkgs that's currently pinned, [it should be `buildGo120Module`](https://github.com/NixOS/nixpkgs/blob/ff8d08cc60eb652ef261b180ce3707b2ff5579c5/pkgs/top-level/all-packages.nix#L25393-L25396) and not the `buildGo121Module` that I originally guessed.

I am also tempted to update the pinned version of Nixpkgs to [the latest commit that's currently available for `nixos-unstable`](https://github.com/NixOS/nixpkgs/commit/54aac082a4d9bb5bbc5c4e899603abfb76a3f6d6), but I'd want permission before doing that. (Possibly for exactly this PR?)

... Also it took me 45 minutes to write this, oops! 😅 