### PR TITLE
Add `-f` flag to `packwiz list`

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -72,12 +72,15 @@ var listCmd = &cobra.Command{
 			}
 		}
 
-		// Print mods in a Markdown table
-		if viper.GetBool("list.markdown") {
-			// Open file for writing
-			file, err := os.Create("modlist.md")
+		// Print mods in a Markdown table to a file
+		if viper.IsSet("list.file") {
+			// Get filename from argument, if any
+			filename := viper.GetString("list.file")
+
+			// Create file
+			file, err := os.Create(filename)
 			if err != nil {
-				fmt.Println(err)
+				fmt.Println("Error creating file:", err)
 				os.Exit(1)
 			}
 			defer file.Close()
@@ -108,7 +111,7 @@ var listCmd = &cobra.Command{
 			}
 
 			// Print success message
-			fmt.Println("Mod list written to modlist.md")
+			fmt.Println("Mod list written to", filename)
 		} else {
 			for _, mod := range mods {
 				fmt.Println(mod.Name)
@@ -124,7 +127,7 @@ func init() {
 	_ = viper.BindPFlag("list.version", listCmd.Flags().Lookup("version"))
 	listCmd.Flags().StringP("side", "s", "", "Filter mods by side (e.g., client or server)")
 	_ = viper.BindPFlag("list.side", listCmd.Flags().Lookup("side"))
-	listCmd.Flags().BoolP("markdown", "m", false, "Print mods in a Markdown table to modlist.md")
-	_ = viper.BindPFlag("list.markdown", listCmd.Flags().Lookup("markdown"))
+	listCmd.Flags().StringP("file", "f", "", "Print mods as a table to a Markdown file")
+	_ = viper.BindPFlag("list.file", listCmd.Flags().Lookup("file"))
 
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -82,13 +82,29 @@ var listCmd = &cobra.Command{
 			}
 			defer file.Close()
 
+			// Initialize max lengths
+			maxNameLen, maxFileNameLen, maxSideLen := 0, 0, 0
+
+			// Find max lengths
+			for _, mod := range mods {
+				if len(mod.Name) > maxNameLen {
+					maxNameLen = len(mod.Name)
+				}
+				if len(mod.FileName) > maxFileNameLen {
+					maxFileNameLen = len(mod.FileName)
+				}
+				if len(mod.Side) > maxSideLen {
+					maxSideLen = len(mod.Side)
+				}
+			}
+
 			// Write header
-			fmt.Fprintln(file, "| Mod name | Version | Side |")
-			fmt.Fprintln(file, "|----------|---------|------|")
+			fmt.Fprintf(file, "| %-*s | %-*s | %-*s |\n", maxNameLen, "Name", maxFileNameLen, "File Name", maxSideLen, "Side")
+			fmt.Fprintf(file, "| %-*s | %-*s | %-*s |\n", maxNameLen, strings.Repeat("-", maxNameLen), maxFileNameLen, strings.Repeat("-", maxFileNameLen), maxSideLen, strings.Repeat("-", maxSideLen))
 
 			// Write mods
 			for _, mod := range mods {
-				fmt.Fprintf(file, "| %s | %s | %s |\n", mod.Name, mod.FileName, mod.Side)
+				fmt.Fprintf(file, "| %-*s | %-*s | %-*s |\n", maxNameLen, mod.Name, maxFileNameLen, mod.FileName, maxSideLen, mod.Side)
 			}
 
 			// Print success message

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -71,6 +71,33 @@ var listCmd = &cobra.Command{
 				fmt.Println(mod.Name)
 			}
 		}
+
+		// Print mods in a Markdown table
+		if viper.GetBool("list.markdown") {
+			// Open file for writing
+			file, err := os.Create("modlist.md")
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+			defer file.Close()
+
+			// Write header
+			fmt.Fprintln(file, "| Mod name | Version | Side |")
+			fmt.Fprintln(file, "|----------|---------|------|")
+
+			// Write mods
+			for _, mod := range mods {
+				fmt.Fprintf(file, "| %s | %s | %s |\n", mod.Name, mod.FileName, mod.Side)
+			}
+
+			// Print success message
+			fmt.Println("Mod list written to modlist.md")
+		} else {
+			for _, mod := range mods {
+				fmt.Println(mod.Name)
+			}
+		}
 	},
 }
 
@@ -81,5 +108,7 @@ func init() {
 	_ = viper.BindPFlag("list.version", listCmd.Flags().Lookup("version"))
 	listCmd.Flags().StringP("side", "s", "", "Filter mods by side (e.g., client or server)")
 	_ = viper.BindPFlag("list.side", listCmd.Flags().Lookup("side"))
+	listCmd.Flags().BoolP("markdown", "m", false, "Print mods in a Markdown table to modlist.md")
+	_ = viper.BindPFlag("list.markdown", listCmd.Flags().Lookup("markdown"))
 
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -91,12 +91,35 @@ var listCmd = &cobra.Command{
 			}
 
 			// Write header
-			fmt.Fprintf(file, "| %-*s | %-*s | %-*s |\n", maxNameLen, "Name", maxFileNameLen, "File Name", maxSideLen, "Side")
-			fmt.Fprintf(file, "| %-*s | %-*s | %-*s |\n", maxNameLen, strings.Repeat("-", maxNameLen), maxFileNameLen, strings.Repeat("-", maxFileNameLen), maxSideLen, strings.Repeat("-", maxSideLen))
+			fmt.Fprintf(file, "| %-*s ", maxNameLen, "Name")
+			if viper.GetBool("list.version") {
+				fmt.Fprintf(file, "| %-*s ", maxFileNameLen, "Version")
+			}
+			if viper.IsSet("list.side") {
+				fmt.Fprintf(file, "| %-*s ", maxSideLen, "Side")
+			}
+			fmt.Fprintln(file, "|")
+
+			// Write separator
+			fmt.Fprintf(file, "| %-*s ", maxNameLen, strings.Repeat("-", maxNameLen))
+			if viper.GetBool("list.version") {
+				fmt.Fprintf(file, "| %-*s ", maxFileNameLen, strings.Repeat("-", maxFileNameLen))
+			}
+			if viper.IsSet("list.side") {
+				fmt.Fprintf(file, "| %-*s ", maxSideLen, strings.Repeat("-", maxSideLen))
+			}
+			fmt.Fprintln(file, "|")
 
 			// Write mods
 			for _, mod := range mods {
-				fmt.Fprintf(file, "| %-*s | %-*s | %-*s |\n", maxNameLen, mod.Name, maxFileNameLen, mod.FileName, maxSideLen, mod.Side)
+				fmt.Fprintf(file, "| %-*s ", maxNameLen, mod.Name)
+				if viper.GetBool("list.version") {
+					fmt.Fprintf(file, "| %-*s ", maxFileNameLen, mod.FileName)
+				}
+				if viper.IsSet("list.side") {
+					fmt.Fprintf(file, "| %-*s ", maxSideLen, mod.Side)
+				}
+				fmt.Fprintln(file, "|")
 			}
 
 			// Print success message

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -61,17 +61,6 @@ var listCmd = &cobra.Command{
 			return strings.ToLower(mods[i].Name) < strings.ToLower(mods[j].Name)
 		})
 
-		// Print mods
-		if viper.GetBool("list.version") {
-			for _, mod := range mods {
-				fmt.Printf("%s (%s)\n", mod.Name, mod.FileName)
-			}
-		} else {
-			for _, mod := range mods {
-				fmt.Println(mod.Name)
-			}
-		}
-
 		// Print mods in a Markdown table to a file
 		if viper.IsSet("list.file") {
 			// Get filename from argument, if any
@@ -112,6 +101,15 @@ var listCmd = &cobra.Command{
 
 			// Print success message
 			fmt.Println("Mod list written to", filename)
+			
+			return
+		}
+
+		// If no file is specified, print to console
+		if viper.GetBool("list.version") {
+			for _, mod := range mods {
+				fmt.Printf("%s (%s)\n", mod.Name, mod.FileName)
+			}
 		} else {
 			for _, mod := range mods {
 				fmt.Println(mod.Name)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -42,13 +42,17 @@ var listCmd = &cobra.Command{
 		// Filter mods by side
 		if viper.IsSet("list.side") {
 			side := viper.GetString("list.side")
+
+			// Validate side
 			if side != core.UniversalSide && side != core.ServerSide && side != core.ClientSide {
 				fmt.Printf("Invalid side %q, must be one of client, server, or both (default)\n", side)
 				os.Exit(1)
 			}
 
+			// Add mods incrementally to the slice
 			i := 0
 			for _, mod := range mods {
+				// Checks for specified side along with "universal" and empty sides
 				if mod.Side == side || mod.Side == core.EmptySide || mod.Side == core.UniversalSide || side == core.UniversalSide {
 					mods[i] = mod
 					i++
@@ -57,6 +61,7 @@ var listCmd = &cobra.Command{
 			mods = mods[:i]
 		}
 
+		// Sort mods alphabetically by name
 		sort.Slice(mods, func(i, j int) bool {
 			return strings.ToLower(mods[i].Name) < strings.ToLower(mods[j].Name)
 		})
@@ -124,7 +129,7 @@ var listCmd = &cobra.Command{
 
 			// Print success message
 			fmt.Println("Mod list written to", filename)
-			
+
 			return
 		}
 


### PR DESCRIPTION
`packwiz list -f [filename]` will write a list of mods to a file in the format of a Markdown table. The flag is compatible with all other flags for `list`.

## Sample outputs

```bash
packwiz list -f list.md
```

| Name                                                    |
| ------------------------------------------------------- |
| A Man With Plushies (AMWPlushies)                       |
| BetterF3                                        |
| Discord Integration                                                 |

```bash
packwiz list -v -f list.md
```

| Name                                                    | Version                                              |
| ------------------------------------------------------- | ---------------------------------------------------- |
| A Man With Plushies (AMWPlushies)                       | amwplushies-forge-1.19.2-2.0.1.jar                   |
| BetterF3                                                | BetterF3-4.0.0-Forge-1.19.2.jar                      |
| Discord Integration                                     | dcintegration-forge-3.0.5-1.19.2.jar                 |

```bash
packwiz list -s client -f list.md
```

| Name                                                    | Side   |
| ------------------------------------------------------- | ------ |
| A Man With Plushies (AMWPlushies)                       | both   |
| BetterF3                                                | client |

```bash
packwiz list -s server -f list.md
```

| Name                                                    | Side   |
| ------------------------------------------------------- | ------ |
| A Man With Plushies (AMWPlushies)                       | both   |
| Discord Integration                                     | server |

```bash
packwiz list -v -s both -f list.md
```

| Name                                                    | Version                                              | Side   |
| ------------------------------------------------------- | ---------------------------------------------------- | ------ |
| A Man With Plushies (AMWPlushies)                       | amwplushies-forge-1.19.2-2.0.1.jar                   | both   |
| BetterF3                                                | BetterF3-4.0.0-Forge-1.19.2.jar                      | client |
| Discord Integration                                     | dcintegration-forge-3.0.5-1.19.2.jar                 | server |

## Notes

The Markdown table is written so that there is no unevenness in each column. Here's a screenshot from Sublime Text with Word Wrap disabled:
![image](https://github.com/packwiz/packwiz/assets/90416865/d23c0617-26a6-4179-8dc5-0e107836165f)
