### PR TITLE
Improve r13y of `packwiz modrinth export` by sorting `manifestFiles`

### DIFF
--- a/modrinth/export.go
+++ b/modrinth/export.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/exp/slices"
 	"net/url"
 	"os"
+	"sort"
 	"strconv"
 
 	"github.com/packwiz/packwiz/core"
@@ -172,6 +173,10 @@ var exportCmd = &cobra.Command{
 				}
 			}
 		}
+		// sort by `path` property before serialising to ensure reproducibility
+		sort.Slice(manifestFiles, func(i, j int) bool {
+			return manifestFiles[i].Path < manifestFiles[j].Path
+		})
 
 		err = session.SaveIndex()
 		if err != nil {


### PR DESCRIPTION
The final `.zip` archival step is also not reproducible, but I can simply extract and recompress.

resolves #244