### PR TITLE
Update Modrinth url regex to accept 'www.'

### DIFF
--- a/modrinth/modrinth.go
+++ b/modrinth/modrinth.go
@@ -186,7 +186,7 @@ func getProjectTypeFolder(projectType string, fileLoaders []string, packLoaders 
 
 var urlRegexes = [...]*regexp.Regexp{
 	// Slug/version number regex from https://github.com/modrinth/labrinth/blob/1679a3f844497d756d0cf272c5374a5236eabd42/src/util/validate.rs#L8
-	regexp.MustCompile("^https?://modrinth\\.com/(?P<urlCategory>[^/]+)/(?P<slug>[a-zA-Z0-9!@$()`.+,_\"-]{3,64})(?:/version/(?P<version>[a-zA-Z0-9!@$()`.+,_\"-]{1,32}))?"),
+	regexp.MustCompile("^https?://(www.)?modrinth\\.com/(?P<urlCategory>[^/]+)/(?P<slug>[a-zA-Z0-9!@$()`.+,_\"-]{3,64})(?:/version/(?P<version>[a-zA-Z0-9!@$()`.+,_\"-]{1,32}))?"),
 	// Version/project IDs are more restrictive: [a-zA-Z0-9]+ (base62)
 	regexp.MustCompile("^https?://cdn\\.modrinth\\.com/data/(?P<slug>[a-zA-Z0-9]+)/versions/(?P<versionID>[a-zA-Z0-9]+)/(?P<filename>[^/]+)$"),
 	regexp.MustCompile("^(?P<slug>[a-zA-Z0-9!@$()`.+,_\"-]{3,64})$"),


### PR DESCRIPTION
Occasionally when copying links from Modrinth, there is a `www.` prepended in the URL -- which leads to `packwiz modrinth add <url>` failing..

This PR addresses this by allowing for Modrinth URL's with a prepended `www.`