### PR TITLE
Add —side flag to explicitly specify whether Modrinth mods should be installed on the client, the server, or both.

### DIFF
--- a/modrinth/install.go
+++ b/modrinth/install.go
@@ -408,9 +408,25 @@ func createFileMeta(project *modrinthApi.Project, version *modrinthApi.Version, 
 		return err
 	}
 
-	side := getSide(project)
+	var side string
+	
+	// Set the side to install based on the value of the --side flag
+	switch sideFlag {
+		case "client":
+			side = core.ClientSide
+		case "server":
+			side = core.ServerSide
+		case "both":
+			side = core.UniversalSide
+		// Determine the correct side automatically if the flag is not specified.
+		case "":
+			side = getSide(project)
+		default:
+			return errors.New("invalid value for --side flag. Expected \"client\", \"server\", or \"both\", got " + "\"" + *&sideFlag + "\"")
+	}
+	
 	if side == "" {
-		return errors.New("version doesn't have a side that's supported. Server: " + *project.ServerSide + " Client: " + *project.ClientSide)
+		return errors.New("version doesn't have a side that's supported. Server: " + *project.ServerSide + " Client: " + *project.ClientSide + ". Use the --side flag to explicitly specify a side (\"client\", \"server\", or \"both\")")
 	}
 
 	algorithm, hash := getBestHash(file)
@@ -458,6 +474,7 @@ func createFileMeta(project *modrinthApi.Project, version *modrinthApi.Version, 
 var projectIDFlag string
 var versionIDFlag string
 var versionFilenameFlag string
+var sideFlag string
 
 func init() {
 	modrinthCmd.AddCommand(installCmd)
@@ -465,4 +482,5 @@ func init() {
 	installCmd.Flags().StringVar(&projectIDFlag, "project-id", "", "The Modrinth project ID to use")
 	installCmd.Flags().StringVar(&versionIDFlag, "version-id", "", "The Modrinth version ID to use")
 	installCmd.Flags().StringVar(&versionFilenameFlag, "version-filename", "", "The Modrinth version filename to use")
+	installCmd.Flags().StringVar(&sideFlag, "side", "", "The side to install (client, server, or both). Detected automatically by default.")
 }


### PR DESCRIPTION
Modrinth allows mods to specify a “side”: whether they are required on the client, the server, or both. However, some mods (for example, [Dynmap](https://modrinth.com/plugin/dynmap)) don’t specify this, and currently packwiz fails for those mods. This PR adds a `—side` flag that allows the user to explicitly set whether the mod should be installed on the client, the server, or both.

This is my first time writing Go, so some parts may unintentionally go against convention. I tried to infer the code style from the rest of the project, though.