### PR TITLE
Change vendorSha256 to vendorHash in nix files

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,18 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703013332,
-        "narHash": "sha256-+tFNwMvlXLbJZXiMHqYq77z/RfmpfpiI3yjL6o/Zo9M=",
+        "lastModified": 1724224976,
+        "narHash": "sha256-Z/ELQhrSd7bMzTO8r7NZgi9g5emh+aRKoCdaAv5fiO0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "54aac082a4d9bb5bbc5c4e899603abfb76a3f6d6",
+        "rev": "c374d94f1536013ca8e92341b540eba4c22f9c62",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
+        "owner": "NixOS",
         "ref": "nixos-unstable",
-        "type": "indirect"
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,46 +1,50 @@
 {
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    # This maps to https://github.com/NixOS/nixpkgs/tree/nixos-unstable
-    # The `url` option is the pattern of `github:USER_OR_ORG/REPO/BRANCH`
+  # This maps to https://github.com/NixOS/nixpkgs/tree/nixos-unstable
+  # The `url` option is the pattern of `github:USER_OR_ORG/REPO/BRANCH`
 
-  outputs = {
-    self,
-    nixpkgs,
-  }:
-    with nixpkgs.lib; let
+  outputs =
+    { self, nixpkgs }:
+    with nixpkgs.lib;
+    let
       # List of explicetely unsupported systems
-      explicitelyUnsupportedSystems = [];
+      explicitelyUnsupportedSystems = [ ];
 
       # Packwiz should support all 64-bit systems supported by go, but nix only
       # support strictly less, so all nix-supported systems are included
       # (except ones in explicitelyUnsupportedSystems).
       supportedSystems =
         filter
-        # Filter out systems that are explicetely supported
-        (s: ! elem s explicitelyUnsupportedSystems)
-        # This lists all systems reasonably well-supported by nix
-        (import "${nixpkgs}/lib/systems/flake-systems.nix" {});
+          # Filter out systems that are explicetely supported
+          (s: !elem s explicitelyUnsupportedSystems)
+          # This lists all systems reasonably well-supported by nix
+          (import "${nixpkgs}/lib/systems/flake-systems.nix" { });
 
       # Helper generating outputs for each supported system
       forAllSystems = genAttrs supportedSystems;
 
       # Import nixpkgs' package set for each system.
-      nixpkgsFor = forAllSystems (system: import nixpkgs {inherit system;});
-    in {
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+    in
+    {
       # Packwiz package
-      packages = forAllSystems (system: let
-        pkgs = nixpkgsFor.${system};
-      in rec {
-        packwiz = pkgs.callPackage ./nix {
-          version = substring 0 8 self.rev or "dirty";
-          vendorSha256 = readFile ./nix/vendor-sha256;
-          buildGoModule = pkgs.buildGoModule;
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        rec {
+          packwiz = pkgs.callPackage ./nix {
+            version = substring 0 8 self.rev or "dirty";
+            vendorHash = readFile ./nix/vendor-sha256;
+            buildGoModule = pkgs.buildGoModule;
             # As of writing, `pkgs.buildGoModule` is aliased to
             # `pkgs.buildGo121Module` in Nixpkgs.
-        };
-        # Build packwiz by default when no package name is specified
-        default = packwiz;
-      });
+          };
+          # Build packwiz by default when no package name is specified
+          default = packwiz;
+        }
+      );
 
       # This flake's nix code formatter
       formatter = forAllSystems (system: nixpkgsFor.${system}.alejandra);

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,38 +1,36 @@
 let
   # Import nixpkgs if needed
-  pkgs = import <nixpkgs> {};
+  pkgs = import <nixpkgs> { };
 in
-  {
-    lib ? pkgs.lib,
-    buildGoModule ? pkgs.buildGoModule,
-    fetchFromGitHub ? pkgs.fetchFromGitHub,
-    installShellFiles ? pkgs.installShellFiles,
-    # version and vendorSha256 should be specified by the caller
-    version ? "latest",
-    vendorSha256,
-  }:
-    buildGoModule rec {
-      pname = "packwiz";
-      inherit version vendorSha256;
+{
+  lib ? pkgs.lib,
+  buildGoModule ? pkgs.buildGoModule,
+  fetchFromGitHub ? pkgs.fetchFromGitHub,
+  installShellFiles ? pkgs.installShellFiles,
+  # version and vendorHash should be specified by the caller
+  version ? "latest",
+  vendorHash,
+}:
+buildGoModule rec {
+  pname = "packwiz";
+  inherit version vendorHash;
 
-      src = ./..;
+  src = ./..;
 
-      nativeBuildInputs = [
-        installShellFiles
-      ];
+  nativeBuildInputs = [ installShellFiles ];
 
-      # Install shell completions
-      postInstall = ''
-        installShellCompletion --cmd packwiz \
-          --bash <($out/bin/packwiz completion bash) \
-          --fish <($out/bin/packwiz completion fish) \
-          --zsh <($out/bin/packwiz completion zsh)
-      '';
+  # Install shell completions
+  postInstall = ''
+    installShellCompletion --cmd packwiz \
+      --bash <($out/bin/packwiz completion bash) \
+      --fish <($out/bin/packwiz completion fish) \
+      --zsh <($out/bin/packwiz completion zsh)
+  '';
 
-      meta = with lib; {
-        description = "A command line tool for editing and distributing Minecraft modpacks, using a git-friendly TOML format";
-        homepage = "https://packwiz.infra.link/";
-        license = licenses.mit;
-        mainProgram = "packwiz";
-      };
-    }
+  meta = with lib; {
+    description = "A command line tool for editing and distributing Minecraft modpacks, using a git-friendly TOML format";
+    homepage = "https://packwiz.infra.link/";
+    license = licenses.mit;
+    mainProgram = "packwiz";
+  };
+}

--- a/nix/prefetcher.nix
+++ b/nix/prefetcher.nix
@@ -1,15 +1,15 @@
 {
   sha256,
-  pkgs ? import <nixpkgs> {},
+  pkgs ? import <nixpkgs> { },
 }:
 pkgs.callPackage (import ./.) {
 
   buildGoModule = pkgs.buildGoModule;
-    ## As of writing, `pkgs.buildGoModule` is aliased to
-    ## `pkgs.buildGo121Module` in Nixpkgs.
-    ## `buildGoModule` is set as `pkgs.buildGoModule` to try and work around
-    ## `vendorHash` issues in the future.
-  vendorSha256 = sha256;
+  ## As of writing, `pkgs.buildGoModule` is aliased to
+  ## `pkgs.buildGo121Module` in Nixpkgs.
+  ## `buildGoModule` is set as `pkgs.buildGoModule` to try and work around
+  ## `vendorHash` issues in the future.
+  vendorHash = sha256;
 }
 // {
   outputHash = sha256;

--- a/nix/vendor-sha256
+++ b/nix/vendor-sha256
@@ -1,0 +1,1 @@
+sha256-yL5pWbVqf6mEpgYsItLnv8nwSmoMP+SE0rX/s7u2vCg=


### PR DESCRIPTION
Fix for https://github.com/packwiz/packwiz/issues/297

Renamed vendorSha256 to vendorHash in flake.nix and default.nix as the current version of buildGoModule requires it to build

Also added the current version's hash as it was missing from the file