### PR TITLE
Add `--releaseType` flag to `update`

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -127,6 +127,7 @@ var UpdateCmd = &cobra.Command{
 		} else {
 			if len(args) < 1 || len(args[0]) == 0 {
 				fmt.Println("Must specify a valid file, or use the --all flag!")
+				fmt.Println("Optional use the --releaseType [release/beta/alpha/latest] flag to specify the release type.")
 				os.Exit(1)
 			}
 			modPath, ok := index.FindMod(args[0])
@@ -223,4 +224,7 @@ func init() {
 
 	UpdateCmd.Flags().BoolP("all", "a", false, "Update all external files")
 	_ = viper.BindPFlag("update.all", UpdateCmd.Flags().Lookup("all"))
+
+	UpdateCmd.Flags().StringP("releaseType", "r", "latest", "Specify the release type to update (e.g., release, beta, alpha, latest)")
+	_ = viper.BindPFlag("update.releaseType", UpdateCmd.Flags().Lookup("releaseType"))
 }

--- a/modrinth/modrinth.go
+++ b/modrinth/modrinth.go
@@ -330,6 +330,18 @@ func getLatestVersion(projectID string, name string, pack core.Pack) (*modrinthA
 		return nil, errors.New("no valid versions found\n\tUse the 'packwiz settings acceptable-versions' command to accept more game versions\n\tTo use datapacks, add a datapack loader mod and specify the datapack-folder option with the folder this mod loads datapacks from")
 	}
 
+	desiredReleaseType := viper.GetString("update.releaseType")
+	if desiredReleaseType == "" {
+		desiredReleaseType = "latest"
+	}
+
+	if desiredReleaseType != "latest" {
+		result = filterVersionsByReleaseType(result, desiredReleaseType)
+		if len(result) == 0 {
+			return nil, fmt.Errorf("no versions found for release type: %s", desiredReleaseType)
+		}
+	}
+
 	// TODO: option to always compare using flexver?
 	// TODO: ask user which one to use?
 	flexverLatest := findLatestVersion(result, gameVersions, true)
@@ -339,6 +351,16 @@ func getLatestVersion(projectID string, name string, pack core.Pack) (*modrinthA
 	}
 
 	return releaseDateLatest, nil
+}
+
+func filterVersionsByReleaseType(versions []*modrinthApi.Version, desiredReleaseType string) []*modrinthApi.Version {
+	var filtered []*modrinthApi.Version
+	for _, version := range versions {
+		if version.VersionType != nil && *version.VersionType == desiredReleaseType {
+			filtered = append(filtered, version)
+		}
+	}
+	return filtered
 }
 
 func getSide(mod *modrinthApi.Project) string {


### PR DESCRIPTION
An optional update flag has been added, allowing you to specify which latest version of the type you want to update to. By default, the latest version will be used, which is the same behavior as before. This will only work with modrinth mods.

For example if you want to update to the latest stable release of the mod just add `--releaseType release` to your update command.