### PR TITLE
Fix neoforge versions

### DIFF
--- a/core/versionutil.go
+++ b/core/versionutil.go
@@ -5,8 +5,9 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"github.com/unascribed/FlexVer/go/flexver"
 	"strings"
+
+	"github.com/unascribed/FlexVer/go/flexver"
 )
 
 type MavenMetadata struct {
@@ -54,7 +55,7 @@ var ModLoaders = map[string]ModLoaderComponent{
 	"neoforge": {
 		Name:              "neoforge",
 		FriendlyName:      "NeoForge",
-		VersionListGetter: FetchMavenVersionPrefixedListStrip("https://maven.neoforged.net/releases/net/neoforged/forge/maven-metadata.xml", "NeoForge"),
+		VersionListGetter: FetchMavenVersionList("https://maven.neoforged.net/releases/net/neoforged/neoforge/maven-metadata.xml"),
 	},
 }
 

--- a/core/versionutil.go
+++ b/core/versionutil.go
@@ -55,7 +55,7 @@ var ModLoaders = map[string]ModLoaderComponent{
 	"neoforge": {
 		Name:              "neoforge",
 		FriendlyName:      "NeoForge",
-		VersionListGetter: FetchMavenWithNeoForgeStyleVersions("https://maven.neoforged.net/releases/net/neoforged/neoforge/maven-metadata.xml", "NeoForge"),
+		VersionListGetter: FetchNeoForge(),
 	},
 }
 
@@ -144,6 +144,20 @@ func hasPrefixSplitDash(str string, prefix string) bool {
 		return true
 	}
 	return false
+}
+
+func FetchNeoForge() func(mcVersion string) ([]string, string, error) {
+	// NeoForge reused Forge's versioning scheme for 1.20.1, but moved to their own versioning scheme for 1.20.2 and above
+	neoforgeOld := FetchMavenVersionPrefixedListStrip("https://maven.neoforged.net/releases/net/neoforged/forge/maven-metadata.xml", "NeoForge")
+	neoforgeNew := FetchMavenWithNeoForgeStyleVersions("https://maven.neoforged.net/releases/net/neoforged/neoforge/maven-metadata.xml", "NeoForge")
+
+	return func(mcVersion string) ([]string, string, error) {
+		if mcVersion == "1.20.1" {
+			return neoforgeOld(mcVersion)
+		} else {
+			return neoforgeNew(mcVersion)
+		}
+	}
 }
 
 func FetchMavenWithNeoForgeStyleVersions(url string, friendlyName string) func(mcVersion string) ([]string, string, error) {


### PR DESCRIPTION
Neoforge seems to have changed the name in their maven, and it no longer appears to be prefixed by version. However, they do use a versioning from which you can obtain the minecraft version. They [seemed fine](<https://discord.com/channels/313125603924639766/313125603924639766/1284976343510945834>) (link to neoforge discord) with that being used.