### PR TITLE
autofill existing pack.toml data

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -21,6 +21,27 @@ var initCmd = &cobra.Command{
 	Short: "Initialise a packwiz modpack",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
+             reinit := viper.GetBool("init.reinit")
+	     if reinit {
+		 pack, err := core.LoadPack()
+		 if err == nil {
+		     // Autofill values from existing pack.toml
+		     viper.Set("init.name", pack.Name)
+		     viper.Set("init.author", pack.Author)
+		     viper.Set("init.version", pack.Version)
+		     viper.Set("init.mc-version", pack.Versions["minecraft"])
+		     if loader, ok := pack.Versions["modloader"]; ok {
+			 viper.Set("init.modloader", loader)
+		     }
+		     fmt.Println("Autofilled existing pack data:")
+		     fmt.Printf("Name: %s\nAuthor: %s\nVersion: %s\nMinecraft Version: %s\nMod Loader: %s\n",
+			 pack.Name, pack.Author, pack.Version, pack.Versions["minecraft"], pack.Versions["modloader"])
+			} else {
+				fmt.Println("Error loading existing pack data:", err)
+				os.Exit(1)
+			}
+	        }
+		
 		_, err := os.Stat(viper.GetString("pack-file"))
 		if err == nil && !viper.GetBool("init.reinit") {
 			fmt.Println("Modpack metadata file already exists, use -r to override!")


### PR DESCRIPTION
This pull request implements a new feature for the packwiz init command, enabling the -r (reinitialize) flag to autofill existing pack.toml data.

**Key Changes:**

- Existence Check: When the -r flag is used, the code checks for the existence of the pack.toml file.
- Data Loading: If the file exists, the current configuration is loaded, and the command-line flags are populated with these existing values (such as the modpack name, author, version, Minecraft version, and mod loader).
- Behavior Preservation: The original functionality remains intact when the -r flag is not used, allowing users to input new values interactively.