### PR TITLE
Fix problems with sides in `packwiz mr add` and `packwiz url add`

### DIFF
--- a/modrinth/install.go
+++ b/modrinth/install.go
@@ -410,7 +410,8 @@ func createFileMeta(project *modrinthApi.Project, version *modrinthApi.Version, 
 
 	side := getSide(project)
 	if side == "" {
-		return errors.New("version doesn't have a side that's supported. Server: " + *project.ServerSide + " Client: " + *project.ClientSide)
+		fmt.Println("Warning: Project doesn't have a side that's supported; assuming universal. Server: " + *project.ServerSide + " Client: " + *project.ClientSide)
+		side = core.UniversalSide
 	}
 
 	algorithm, hash := getBestHash(file)

--- a/url/install.go
+++ b/url/install.go
@@ -72,6 +72,7 @@ var installCmd = &cobra.Command{
 		modMeta := core.Mod{
 			Name:     args[0],
 			FileName: filename,
+			Side:     core.UniversalSide,
 			Download: core.ModDownload{
 				URL:        args[1],
 				HashFormat: "sha256",


### PR DESCRIPTION
`packwiz mr add` would unconditionally fail if a project doesn't specify a side (i.e. it's not marked as `client` *or* `server`).

Similarly, `packwiz url add` did not specify a `side` value in the metadata.

This PR makes it so that both situations fall back to `both` sides - the user can always manually edit the `.pw.toml` afterwards.