### PR TITLE
feat: Add purpur plugin loader

### DIFF
--- a/core/pack.go
+++ b/core/pack.go
@@ -204,6 +204,14 @@ func (pack Pack) GetCompatibleLoaders() (loaders []string) {
 	} else if _, hasForge := pack.Versions["forge"]; hasForge {
 		loaders = append(loaders, "forge")
 	}
+
+	// As far as I can tell purpur is backwards compatible with all these
+	if _, hasPurpur := pack.Versions["purpur"]; hasPurpur {
+		loaders = append(loaders, "purpur")
+		loaders = append(loaders, "paper")
+		loaders = append(loaders, "spigot")
+		loaders = append(loaders, "bukkit")
+	}
 	return
 }
 

--- a/core/versionutil.go
+++ b/core/versionutil.go
@@ -57,6 +57,37 @@ var ModLoaders = map[string]ModLoaderComponent{
 		FriendlyName:      "NeoForge",
 		VersionListGetter: FetchNeoForge(),
 	},
+	"purpur": {
+		Name:              "purpur",
+		FriendlyName:      "Purpur Plugin loader",
+		VersionListGetter: FetchPurpur(),
+	},
+}
+
+type PurpurMetadata struct {
+	Project          string `json:"project"`
+	VersionMinecraft string `json:"version"`
+	Builds           struct {
+		Latest string   `json:"latest"`
+		All    []string `json:"all"`
+	} `json:"builds"`
+}
+
+func FetchPurpur() func(mcVersion string) ([]string, string, error) {
+	return func(mcVersion string) ([]string, string, error) {
+		url := fmt.Sprintf("https://api.purpurmc.org/v2/purpur/%s", mcVersion)
+		res, err := GetWithUA(url, "application/json")
+		if err != nil {
+			return []string{}, "", err
+		}
+		dec := json.NewDecoder(res.Body)
+		out := PurpurMetadata{}
+		err = dec.Decode(&out)
+		if err != nil {
+			return []string{}, "", err
+		}
+		return out.Builds.All, out.Builds.Latest, nil
+	}
 }
 
 func FetchMavenVersionList(url string) func(mcVersion string) ([]string, string, error) {


### PR DESCRIPTION
Purpur (https://github.com/PurpurMC/Purpur) is a plugin loader that is a drop in for Paper (which is a fork of Spigot (which is a modified version of Bukkit))  

To preface it is my first time using Go, apologies if its not in the style ye normally use.  
I copied from other structs and functions and it seems to work.

I gave it a small test to see if it was working and running ``go run ../ modrinth install Geyser`` brought down the right version:  
![image](https://github.com/user-attachments/assets/b11412b9-9676-4f3d-b5e7-6e2758b3b70b)

Because Purpur uses a custom API for their version matching had to create a new function to be able to pull from that.

Relates to #232 

