### PR TITLE
Publish to Github Releases

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -71,3 +71,16 @@ jobs:
       with:
         name: macOS 64-bit ARM
         path: dist/packwiz_darwin_arm64/
+
+    - name: Set short git commit SHA
+      id: vars
+      run: |
+        calculatedSha=$(git rev-parse --short ${{ github.sha }})
+        echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_ENV
+
+    - name: Create release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        tag: ${{ env.COMMIT_SHORT_SHA }}
+        file_glob: true
+        file: dist/*.tar.gz

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -72,15 +72,13 @@ jobs:
         name: macOS 64-bit ARM
         path: dist/packwiz_darwin_arm64/
 
-    - name: Set short git commit SHA
+    - name: Set Tag
       id: vars
-      run: |
-        calculatedSha=$(git rev-parse --short ${{ github.sha }})
-        echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_ENV
+      run: echo "TAG=$(date +%s)" >> $GITHUB_ENV
 
     - name: Create release
       uses: svenstaro/upload-release-action@v2
       with:
-        tag: ${{ env.COMMIT_SHORT_SHA }}
+        tag: ${{ env.TAG }}
         file_glob: true
         file: dist/*.tar.gz

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,3 +19,5 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+archives:
+  - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"


### PR DESCRIPTION
While trying to build my own set of github actions for automating modpack releases, I discovered that nightly.link direct download links only work for 90 days from the most recent build. 
![image](https://github.com/user-attachments/assets/3bdbb549-24f1-47b2-b180-b82955a3cc14)
To provide direct download links for my own projects, I use GitHub Releases. This PR adds to your existing go build action to upload the release archives to a new timestamped release tag, such that the latest download is always available from GitHub at https://github.com/packwiz/packwiz/releases/latest/download/packwiz_os_arch.tar.gz along with providing a much nicer UI compared to release artifacts.