### PR TITLE
Fix minecraft version 1.21.1 pulling in NeoForge versions for 1.21.10

### DIFF
--- a/core/versionutil.go
+++ b/core/versionutil.go
@@ -177,7 +177,11 @@ func FetchMavenWithNeoForgeStyleVersions(url string, friendlyName string) func(m
 		if len(mcSplit) > 2 {
 			mcMinor = mcSplit[2]
 		}
-		return strings.HasPrefix(neoforgeVersion, mcMajor+"."+mcMinor)
+
+		// We can only accept an exact version number match, because otherwise 1.21.1 would pull in loader versions for 1.21.10.
+		var requiredPrefix = mcMajor + "." + mcMinor + "."
+
+		return strings.HasPrefix(neoforgeVersion, requiredPrefix)
 	})
 }
 


### PR DESCRIPTION
Since the compatibility check only verifies that the first characters match between the version strings, a one-character patch version could be misinterpreted if a two-character patch version exists.

For instance, if the minecraft version is set to 1.21.1, `packwiz init` recommends a NeoForge version for 1.21.10:
```sh
karcsesz@Littlepip ~/repro [1]> ../packwiz/packwiz init
Modpack name [Repro]:
Author:
Version [1.0.0]:
Minecraft version [1.21.10]: 1.21.1
Mod loader [quilt]: neoforge
NeoForge version [21.10.20-beta]:
```

This PR adds the trailing period as a required part of the string to match, which *should* be safe, because NeoForge versions always contain all three components (except in the case of April Fools builds, which this PR doesn't fix).