### PR TITLE
Fix loader comparison when unrecognized loader is encountered

### DIFF
--- a/modrinth/modrinth.go
+++ b/modrinth/modrinth.go
@@ -260,7 +260,7 @@ func compareLoaderLists(a []string, b []string) int32 {
 			continue
 		}
 		idx := slices.Index(loaderPreferenceList, v)
-		if idx < minIdxA {
+		if idx != -1 && idx < minIdxA {
 			return 1 // B has more preferable loaders
 		}
 		if idx != -1 && idx < minIdxB {


### PR DESCRIPTION
Since an unrecognized loader has an index of -1, and since lower number indicate a better loader, an unrecognized loader (when found in b) would immediately be assumed to be a great loader. Since the loop for A properly handles it, B would always be assumed to be the best, which has quite wrong consequences.

This is caused by some new loaders being added to modrinth ([modrinth discord message](https://discord.com/channels/734077874708938864/974050507150729236/1384334955001417728)). The new loaders should probably be added into packwiz, but the comparison function should be fixed to in case of future additions

Fixes #365 