### PR TITLE
Exit on download failure during modrinth pack export

### DIFF
--- a/modrinth/export.go
+++ b/modrinth/export.go
@@ -105,7 +105,7 @@ var exportCmd = &cobra.Command{
 			if canBeIncludedDirectly(dl.Mod, restrictDomains) {
 				if dl.Error != nil {
 					fmt.Printf("Download of %s (%s) failed: %v\n", dl.Mod.Name, dl.Mod.FileName, dl.Error)
-					continue
+					os.Exit(1)
 				}
 				for _, warning := range dl.Warnings {
 					fmt.Printf("Warning for %s (%s): %v\n", dl.Mod.Name, dl.Mod.FileName, warning)


### PR DESCRIPTION
If `packwiz modrinth export` fails to download a mod, it just continues and creates the `mrpack` but without the mod.

It's not clear if this is the intended behaviour, but I think it makes more sense for the export to fail in this case.