### PR TITLE
chore: update nix vendor hash

### DIFF
--- a/nix/vendor-hash
+++ b/nix/vendor-hash
@@ -1,0 +1,1 @@
+sha256-ChUE4hWl+UyPpbzK0GbJTD0AoBCogI7qGstga4+WujI=


### PR DESCRIPTION
This commit re-adds the vendor hash. It doesn't resolve the underlying issue presented in #387, but it should allow for building.

Tested on `aarch64-darwin` and `x86_64-linux`.
