### PR TITLE
Support directories as values for the `--output` option during export

### DIFF
--- a/core/pack.go
+++ b/core/pack.go
@@ -222,3 +222,13 @@ func (pack Pack) GetLoaders() (loaders []string) {
 	}
 	return
 }
+
+func (pack Pack) CreateExportFile(fileName string, defaultFileExt string) (*os.File, error) {
+	// If fileName doesn't have an extension, treat it as a directory name.
+	if len(filepath.Ext(fileName)) <= 1 {
+		fileName = filepath.Join(fileName, pack.GetPackName()+defaultFileExt)
+	}
+
+	os.MkdirAll(filepath.Dir(fileName), 0755)
+	return os.Create(fileName)
+}

--- a/curseforge/export.go
+++ b/curseforge/export.go
@@ -86,12 +86,7 @@ var exportCmd = &cobra.Command{
 			}
 		}
 
-		fileName := viper.GetString("curseforge.export.output")
-		if fileName == "" {
-			fileName = pack.GetPackName() + ".zip"
-		}
-
-		expFile, err := os.Create(fileName)
+		expFile, err := pack.CreateExportFile(viper.GetString("curseforge.export.output"), ".zip")
 		if err != nil {
 			fmt.Printf("Failed to create zip: %s\n", err.Error())
 			os.Exit(1)
@@ -183,7 +178,7 @@ var exportCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		fmt.Println("Modpack exported to " + fileName)
+		fmt.Println("Modpack exported to " + expFile.Name())
 	},
 }
 
@@ -228,6 +223,6 @@ func init() {
 
 	exportCmd.Flags().StringP("side", "s", "client", "The side to export mods with")
 	_ = viper.BindPFlag("curseforge.export.side", exportCmd.Flags().Lookup("side"))
-	exportCmd.Flags().StringP("output", "o", "", "The file to export the modpack to")
+	exportCmd.Flags().StringP("output", "o", "", "The file or directory to export the modpack to")
 	_ = viper.BindPFlag("curseforge.export.output", exportCmd.Flags().Lookup("output"))
 }

--- a/modrinth/export.go
+++ b/modrinth/export.go
@@ -63,11 +63,7 @@ var exportCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		fileName := viper.GetString("modrinth.export.output")
-		if fileName == "" {
-			fileName = pack.GetPackName() + ".mrpack"
-		}
-		expFile, err := os.Create(fileName)
+		expFile, err := pack.CreateExportFile(viper.GetString("modrinth.export.output"), ".mrpack")
 		if err != nil {
 			fmt.Printf("Failed to create zip: %s\n", err.Error())
 			os.Exit(1)
@@ -248,7 +244,7 @@ var exportCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		fmt.Println("Modpack exported to " + fileName)
+		fmt.Println("Modpack exported to " + expFile.Name())
 	},
 }
 
@@ -278,7 +274,7 @@ func canBeIncludedDirectly(mod *core.Mod, restrictDomains bool) bool {
 func init() {
 	modrinthCmd.AddCommand(exportCmd)
 	exportCmd.Flags().Bool("restrictDomains", true, "Restricts domains to those allowed by modrinth.com")
-	exportCmd.Flags().StringP("output", "o", "", "The file to export the modpack to")
+	exportCmd.Flags().StringP("output", "o", "", "The file or directory to export the modpack to")
 	_ = viper.BindPFlag("modrinth.export.restrictDomains", exportCmd.Flags().Lookup("restrictDomains"))
 	_ = viper.BindPFlag("modrinth.export.output", exportCmd.Flags().Lookup("output"))
 }


### PR DESCRIPTION
This is both a fix and a feature.

Starting with the fix, currently, if you include a directory name in `--output` *(e.g., `--output build/pack.mrpack`)*, packwiz fails if the specified directory does not already exist. This is a bug, since it's generally expected from a build tool to be able to create the directory it needs to place the artifacts into. This PR fixes that.

Additionally, I'd like to be able to specify the output simply as a directory name, so the default artifact name provided by packwiz is not overridden by my input *(e.g., `--output build`)*. This is also a pretty standard feature in many build tools. Since packwiz's output pretty much requires an extension *(be that `.zip` or `.mrpack`)*, I added a simple heuristic: if the provided path has no extension, it is treated as a directory, and the default artifact name is appended to it.