### PR TITLE
Prevent invalid export filenames by using slugs instead of display names

### DIFF
--- a/core/pack.go
+++ b/core/pack.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"unicode"
 
 	"github.com/BurntSushi/toml"
 	"github.com/Masterminds/semver/v3"
@@ -181,13 +182,33 @@ func (pack Pack) GetSupportedMCVersions() ([]string, error) {
 	return allVersionsDeduped, nil
 }
 
+func (pack Pack) GetSlug() string {
+	var builder strings.Builder
+	builder.Grow(len(pack.Name))
+	isSpace := true
+	for _, r := range pack.Name {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' {
+			builder.WriteRune(unicode.ToLower(r))
+			isSpace = false
+		} else if unicode.IsSpace(r) && !isSpace {
+			builder.WriteRune('-')
+			isSpace = true
+		}
+	}
+
+	slug := strings.TrimRight(builder.String(), "-")
+	if slug == "" {
+		slug = "export"
+	}
+
+	return slug
+}
+
 func (pack Pack) GetPackName() string {
-	if pack.Name == "" {
-		return "export"
-	} else if pack.Version == "" {
-		return pack.Name
+	if pack.Version == "" {
+		return pack.GetSlug()
 	} else {
-		return pack.Name + "-" + pack.Version
+		return pack.GetSlug() + "-" + pack.Version
 	}
 }
 


### PR DESCRIPTION
This is partly a feature and partly a bug fix as well.

At the moment, packwiz blindly accepts the `name` field from `pack.toml` as the default name for exported modpacks. This shouldn't be the case, because a modpack's display name is generally not that good of a fit for a filename.

First of all, it can easily contain illegal characters. For example, my pack includes a `:` in its name. While packwiz builds it just fine on Linux, attempting the same on Windows will fail, as `:` is a forbidden character there. And even setting illegal file paths aside, using a display name as-is often results in just awkward filenames that may include spaces, punctuation, and other symbols we usually try to avoid when naming files.

To address both of these issues, I suggest using slugs as the basis for the default filename. While packwiz does not define a `slug` field in `pack.toml` *(and I would prefer not to add one right niw, as that would require updating  the schema of the file)*, it is quite straightforward to slugify the display name provided by the user. I went with the following rules: convert the name to lowercase, replace whitespace with `-`, keep digits as-is, remove everything else.