### PR TITLE
Support aliased files in pack exports

### DIFF
--- a/cmdshared/downloadutil.go
+++ b/cmdshared/downloadutil.go
@@ -68,7 +68,7 @@ func AddToZip(dl core.CompletedDownload, exp *zip.Writer, dir string, index *cor
 func AddNonMetafileOverrides(index *core.Index, exp *zip.Writer) {
 	for p, v := range index.Files {
 		if !v.IsMetaFile() {
-			file, err := exp.Create(path.Join("overrides", p))
+			file, err := exp.Create(path.Join("overrides", v.AliasPath()))
 			if err != nil {
 				fmt.Printf("Error creating file: %s\n", err.Error())
 				// TODO: exit(1)?

--- a/core/indexfiles.go
+++ b/core/indexfiles.go
@@ -16,6 +16,8 @@ type IndexPathHolder interface {
 	markMetaFile()
 	markedFound() bool
 	IsMetaFile() bool
+	// Returns Alias if set, otherwise File.
+	AliasPath() string
 }
 
 // indexFile is a file in the index
@@ -49,6 +51,13 @@ func (i *indexFile) markedFound() bool {
 
 func (i *indexFile) IsMetaFile() bool {
 	return i.MetaFile
+}
+
+func (i *indexFile) AliasPath() string {
+	if i.Alias != "" {
+		return i.Alias
+	}
+	return i.File
 }
 
 type indexFileMultipleAlias map[string]indexFile
@@ -85,6 +94,13 @@ func (i *indexFileMultipleAlias) markedFound() bool {
 func (i *indexFileMultipleAlias) IsMetaFile() bool {
 	for _, v := range *i {
 		return v.MetaFile
+	}
+	panic("No entries in indexFileMultipleAlias")
+}
+
+func (i *indexFileMultipleAlias) AliasPath() string {
+	for _, v := range *i {
+		return v.AliasPath()
 	}
 	panic("No entries in indexFileMultipleAlias")
 }


### PR DESCRIPTION
Previously, the `Alias` field was not respected when exporting modpacks using `packwiz modrinth export` or `packwiz curseforge export`. This PR fixes that by adding the `AliasPath()` method to the `IndexPathHolder` interface (& adding impls to things implementing that interface), as well as using the aforementioned method in `downloadutil`'s `AddNonMetafileOverrides` function. `AliasPath()` returns either the value of `Alias`, or the value of `File` if `Alias` is empty.  `Alias`, according to the [documentation](https://packwiz.infra.link/reference/pack-format/index-toml/#properties_1), is incompatible with `Metafile`, so I didn't change anything relating to metafile handling / downloading.

This PR was tested against [`d072061eb9`](https://c.csw.im/GalacticFactory/ClockworkAviation/src/commit/d072061eb92e9660dd91308cb9ac23ce5604bf8f), and works fine in my limited testing.