### PR TITLE
Add unit-test coverage for the existing codebase

### DIFF
--- a/cmdshared/mcversion_test.go
+++ b/cmdshared/mcversion_test.go
@@ -1,0 +1,38 @@
+package cmdshared
+
+import (
+	"testing"
+	"time"
+)
+
+// CheckValid calls os.Exit(1) on miss, so only the success path is
+// testable here. Calling the failure path would terminate the test
+// binary. See .claude/TODO.md ("Audit and improve error handling")
+// for the broader refactor — these helpers should return errors
+// rather than calling os.Exit directly.
+
+func TestMcVersionManifestCheckValid_Success(t *testing.T) {
+	type versionEntry = struct {
+		ID          string    `json:"id"`
+		Type        string    `json:"type"`
+		URL         string    `json:"url"`
+		Time        time.Time `json:"time"`
+		ReleaseTime time.Time `json:"releaseTime"`
+	}
+
+	m := McVersionManifest{
+		Versions: []versionEntry{
+			{ID: "1.19.4"},
+			{ID: "1.20.1"},
+			{ID: "1.20.2"},
+		},
+	}
+
+	// Each of these is present in the manifest; CheckValid should
+	// return silently. A regression would terminate the test process.
+	for _, version := range []string{"1.19.4", "1.20.1", "1.20.2"} {
+		t.Run(version, func(t *testing.T) {
+			m.CheckValid(version)
+		})
+	}
+}

--- a/cmdshared/utils_test.go
+++ b/cmdshared/utils_test.go
@@ -1,0 +1,44 @@
+package cmdshared
+
+import "testing"
+
+func TestGetRawForgeVersion(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "no dash returns input unchanged",
+			input: "47.1.0",
+			want:  "47.1.0",
+		},
+		{
+			name:  "mcVersion-loaderVersion strips the mcVersion prefix",
+			input: "1.20.1-47.1.0",
+			want:  "47.1.0",
+		},
+		{
+			// Versions can include further dashes (rc / beta tails); the
+			// function uses Split(...)[1], so it returns only the segment
+			// between the first and second dash. Pinning this behavior;
+			// callers that expect the full tail need a different parser.
+			name:  "second dash truncates the version tail",
+			input: "1.20.1-47.1.0-rc1",
+			want:  "47.1.0",
+		},
+		{
+			name:  "empty input passes through",
+			input: "",
+			want:  "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := GetRawForgeVersion(tc.input); got != tc.want {
+				t.Errorf("GetRawForgeVersion(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/core/download_test.go
+++ b/core/download_test.go
@@ -1,0 +1,105 @@
+package core
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestSelectPreferredHash(t *testing.T) {
+	cases := []struct {
+		name       string
+		hashes     map[string]string
+		wantFormat string
+		wantHash   string
+	}{
+		{
+			name:       "empty map yields empty selection",
+			hashes:     map[string]string{},
+			wantFormat: "",
+			wantHash:   "",
+		},
+		{
+			name:       "only murmur2 present",
+			hashes:     map[string]string{"murmur2": "1234"},
+			wantFormat: "murmur2",
+			wantHash:   "1234",
+		},
+		{
+			name:       "only sha256 present",
+			hashes:     map[string]string{"sha256": "abc"},
+			wantFormat: "sha256",
+			wantHash:   "abc",
+		},
+		{
+			// preferredHashList iterates murmur2 → md5 → sha1 → sha256
+			// → sha512. The function overwrites currHash on each match,
+			// so the last (strongest) match wins.
+			name: "strongest hash wins when several present",
+			hashes: map[string]string{
+				"murmur2": "1",
+				"sha1":    "2",
+				"sha512":  "3",
+			},
+			wantFormat: "sha512",
+			wantHash:   "3",
+		},
+		{
+			name:       "unknown formats are ignored",
+			hashes:     map[string]string{"blake3": "x"},
+			wantFormat: "",
+			wantHash:   "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotFormat, gotHash := selectPreferredHash(tc.hashes)
+
+			if gotFormat != tc.wantFormat || gotHash != tc.wantHash {
+				t.Errorf("got (%q, %q), want (%q, %q)",
+					gotFormat, gotHash, tc.wantFormat, tc.wantHash)
+			}
+		})
+	}
+}
+
+func TestGetHashListsForDownload(t *testing.T) {
+	t.Run("validate format matches cache format and no extras", func(t *testing.T) {
+		// cacheHashFormat is "sha256" — when validation is also sha256,
+		// the returned hashesToObtain list should be empty.
+		extras, validateMap := getHashListsForDownload(nil, "sha256", "abc")
+
+		if len(extras) != 0 {
+			t.Errorf("extras = %v, want empty", extras)
+		}
+
+		if !reflect.DeepEqual(validateMap, map[string]string{"sha256": "abc"}) {
+			t.Errorf("validateMap = %v, want {sha256: abc}", validateMap)
+		}
+	})
+
+	t.Run("validate format differs from cache format", func(t *testing.T) {
+		// When validating with md5, the cache still wants sha256, so
+		// sha256 ends up in the extras list.
+		extras, validateMap := getHashListsForDownload(nil, "md5", "xyz")
+
+		if !slices.Contains(extras, "sha256") {
+			t.Errorf("extras = %v, want it to contain sha256", extras)
+		}
+
+		if validateMap["md5"] != "xyz" {
+			t.Errorf("validateMap[md5] = %q, want xyz", validateMap["md5"])
+		}
+	})
+
+	t.Run("hashesToObtain deduplicates against validate and cache formats", func(t *testing.T) {
+		// Asking for sha256 + sha512 while validating with sha256 (and
+		// cache also sha256) should yield only sha512 in extras.
+		extras, _ := getHashListsForDownload([]string{"sha256", "sha512"}, "sha256", "abc")
+
+		if !reflect.DeepEqual(extras, []string{"sha512"}) {
+			t.Errorf("extras = %v, want [sha512]", extras)
+		}
+	})
+}

--- a/core/example_pack_test.go
+++ b/core/example_pack_test.go
@@ -1,0 +1,241 @@
+package core
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// passthroughUpdater satisfies the Updater interface for tests that
+// need to load mod files referencing update plugins. ParseUpdate
+// returns the input unchanged; the other methods panic because they
+// should never be called by these tests.
+type passthroughUpdater struct{}
+
+func (passthroughUpdater) ParseUpdate(in map[string]interface{}) (interface{}, error) {
+	return in, nil
+}
+
+func (passthroughUpdater) CheckUpdate([]*Mod, Pack) ([]UpdateCheck, error) {
+	panic("passthroughUpdater.CheckUpdate should not be called in tests")
+}
+
+func (passthroughUpdater) DoUpdate([]*Mod, []interface{}) error {
+	panic("passthroughUpdater.DoUpdate should not be called in tests")
+}
+
+// registerTestUpdaters installs passthrough updaters for "modrinth"
+// and "curseforge" — the two backends referenced by mods in the
+// vendored example pack — and restores prior state at test cleanup so
+// the global Updaters map isn't polluted across tests.
+func registerTestUpdaters(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{"modrinth", "curseforge"} {
+		name := name
+		prev, existed := Updaters[name]
+		Updaters[name] = passthroughUpdater{}
+
+		t.Cleanup(func() {
+			if existed {
+				Updaters[name] = prev
+			} else {
+				delete(Updaters, name)
+			}
+		})
+	}
+}
+
+// copyExamplePack replicates the vendored example pack into a temp
+// directory and returns its root path. Tests that mutate the pack
+// (Refresh, Write) get a fresh isolated copy each invocation.
+func copyExamplePack(t *testing.T) string {
+	t.Helper()
+
+	dst := t.TempDir()
+	src := filepath.Join("testdata", "example-pack")
+
+	err := filepath.Walk(src, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(src, p)
+		if err != nil {
+			return err
+		}
+
+		target := filepath.Join(dst, rel)
+
+		if info.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+
+		in, err := os.Open(p)
+		if err != nil {
+			return err
+		}
+		defer in.Close()
+
+		out, err := os.Create(target)
+		if err != nil {
+			return err
+		}
+		defer out.Close()
+
+		_, err = io.Copy(out, in)
+		return err
+	})
+
+	if err != nil {
+		t.Fatalf("copyExamplePack: %v", err)
+	}
+
+	return dst
+}
+
+func TestPack_UpdateIndexHash_FromExamplePack(t *testing.T) {
+	packRoot := copyExamplePack(t)
+	packPath := filepath.Join(packRoot, "pack.toml")
+
+	t.Cleanup(func() {
+		viper.Set("pack-file", "")
+		viper.Set("no-internal-hashes", false)
+	})
+	viper.Set("pack-file", packPath)
+	viper.Set("no-internal-hashes", false)
+
+	pack, err := LoadPack()
+	if err != nil {
+		t.Fatalf("LoadPack: %v", err)
+	}
+
+	// Clear the hash that came from the vendored pack.toml so we can
+	// verify UpdateIndexHash recomputes it correctly.
+	pack.Index.Hash = ""
+
+	if err := pack.UpdateIndexHash(); err != nil {
+		t.Fatalf("UpdateIndexHash: %v", err)
+	}
+
+	// This is the value recorded in the vendored pack.toml. If
+	// UpdateIndexHash produces something different, either our hash
+	// pipeline regressed or the vendored fixture diverged from
+	// upstream.
+	const expected = "29bcf953b90081730cd8a32cc4d855ab6ad96685c3aeea6ed033dc4f04d390ac"
+
+	if pack.Index.Hash != expected {
+		t.Errorf("Index.Hash = %q, want %q", pack.Index.Hash, expected)
+	}
+
+	if pack.Index.HashFormat != "sha256" {
+		t.Errorf("Index.HashFormat = %q, want sha256", pack.Index.HashFormat)
+	}
+}
+
+func TestIndex_LoadAllMods_FromExamplePack(t *testing.T) {
+	registerTestUpdaters(t)
+
+	packRoot := copyExamplePack(t)
+	indexPath := filepath.Join(packRoot, "index.toml")
+
+	index, err := LoadIndex(indexPath)
+	if err != nil {
+		t.Fatalf("LoadIndex: %v", err)
+	}
+
+	mods, err := index.LoadAllMods()
+	if err != nil {
+		t.Fatalf("LoadAllMods: %v", err)
+	}
+
+	if len(mods) != 2 {
+		t.Fatalf("loaded %d mods, want 2", len(mods))
+	}
+
+	names := map[string]bool{}
+	for _, m := range mods {
+		names[m.Name] = true
+	}
+
+	for _, want := range []string{"Borderless Mining", "Screenshot to Clipboard (Fabric)"} {
+		if !names[want] {
+			t.Errorf("expected mod %q not loaded; got %v", want, names)
+		}
+	}
+
+	// The two example mods reference different backends; verify
+	// GetParsedUpdateData was populated for each.
+	for _, m := range mods {
+		var key string
+		if m.Name == "Borderless Mining" {
+			key = "modrinth"
+		} else {
+			key = "curseforge"
+		}
+
+		if _, ok := m.GetParsedUpdateData(key); !ok {
+			t.Errorf("mod %q has no parsed update data for %q", m.Name, key)
+		}
+	}
+}
+
+func TestIndex_Refresh_FromExamplePack(t *testing.T) {
+	packRoot := copyExamplePack(t)
+	packPath := filepath.Join(packRoot, "pack.toml")
+	indexPath := filepath.Join(packRoot, "index.toml")
+
+	t.Cleanup(func() {
+		viper.Set("pack-file", "")
+		viper.Set("no-internal-hashes", false)
+	})
+	viper.Set("pack-file", packPath)
+	viper.Set("no-internal-hashes", false)
+
+	index, err := LoadIndex(indexPath)
+	if err != nil {
+		t.Fatalf("LoadIndex: %v", err)
+	}
+
+	// Capture pre-refresh hashes for the three expected entries.
+	before := map[string]string{}
+	for path, holder := range index.Files {
+		f, ok := holder.(*indexFile)
+		if !ok {
+			t.Fatalf("unexpected holder type for %q: %T", path, holder)
+		}
+		before[path] = f.Hash
+	}
+
+	if len(before) != 3 {
+		t.Fatalf("expected 3 entries in vendored index, got %d", len(before))
+	}
+
+	if err := index.Refresh(); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	if len(index.Files) != 3 {
+		t.Errorf("expected 3 entries after refresh, got %d", len(index.Files))
+	}
+
+	for path, wantHash := range before {
+		holder, ok := index.Files[path]
+		if !ok {
+			t.Errorf("entry %q missing after refresh", path)
+			continue
+		}
+
+		f, ok := holder.(*indexFile)
+		if !ok {
+			t.Errorf("entry %q has unexpected holder type %T", path, holder)
+			continue
+		}
+
+		if f.Hash != wantHash {
+			t.Errorf("entry %q hash changed across refresh: %q → %q", path, wantHash, f.Hash)
+		}
+	}
+}

--- a/core/hash_test.go
+++ b/core/hash_test.go
@@ -1,0 +1,191 @@
+package core
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestGetHashImpl(t *testing.T) {
+	cases := []struct {
+		name       string
+		hashType   string
+		wantErr    bool
+		wantString string // expected HashToString output when hashing the empty input
+	}{
+		{
+			name:       "sha1",
+			hashType:   "sha1",
+			wantString: "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+		},
+		{
+			name:       "sha256",
+			hashType:   "sha256",
+			wantString: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		},
+		{
+			name:       "sha512",
+			hashType:   "sha512",
+			wantString: "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
+		},
+		{
+			name:       "md5",
+			hashType:   "md5",
+			wantString: "d41d8cd98f00b204e9800998ecf8427e",
+		},
+		{
+			name:     "murmur2 yields a decimal string",
+			hashType: "murmur2",
+			// Regression pin: murmur2 (CF variant) of empty input.
+			// The non-zero value reflects the algorithm's
+			// initialization constant, not a bug.
+			wantString: "1540447798",
+		},
+		{
+			name:       "length-bytes for empty input is zero",
+			hashType:   "length-bytes",
+			wantString: "0",
+		},
+		{
+			name:       "case-insensitive on the type name",
+			hashType:   "SHA256",
+			wantString: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		},
+		{
+			name:     "unknown type returns an error",
+			hashType: "blake3",
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			impl, err := GetHashImpl(tc.hashType)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for hash type %q, got nil", tc.hashType)
+				}
+
+				if impl != nil {
+					t.Errorf("expected nil HashStringer on error, got %T", impl)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error for hash type %q: %v", tc.hashType, err)
+			}
+
+			if impl == nil {
+				t.Fatalf("expected non-nil HashStringer for %q", tc.hashType)
+			}
+
+			got := impl.HashToString(impl.Sum(nil))
+
+			if got != tc.wantString {
+				t.Errorf("HashToString for %q on empty input = %q, want %q",
+					tc.hashType, got, tc.wantString)
+			}
+		})
+	}
+}
+
+func TestHashToString(t *testing.T) {
+	cases := []struct {
+		name      string
+		hashType  string
+		input     []byte
+		want      string
+	}{
+		{
+			name:     "hexStringer encodes bytes as lowercase hex",
+			hashType: "sha1",
+			input:    []byte{0xde, 0xad, 0xbe, 0xef},
+			want:     "deadbeef",
+		},
+		{
+			name:     "number32As64Stringer decodes big-endian uint32 to decimal",
+			hashType: "murmur2",
+			input:    []byte{0x00, 0x00, 0x00, 0x2a}, // 42 big-endian
+			want:     "42",
+		},
+		{
+			name:     "number64Stringer decodes big-endian uint64 to decimal",
+			hashType: "length-bytes",
+			input:    []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00}, // 1024
+			want:     "1024",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			impl, err := GetHashImpl(tc.hashType)
+			if err != nil {
+				t.Fatalf("setup: GetHashImpl(%q): %v", tc.hashType, err)
+			}
+
+			got := impl.HashToString(tc.input)
+
+			if got != tc.want {
+				t.Errorf("%s.HashToString(%v) = %q, want %q",
+					tc.hashType, tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLengthHasher(t *testing.T) {
+	h := &LengthHasher{}
+
+	if got := h.Size(); got != 8 {
+		t.Errorf("Size() = %d, want 8", got)
+	}
+
+	if got := h.BlockSize(); got != 1 {
+		t.Errorf("BlockSize() = %d, want 1", got)
+	}
+
+	n, err := h.Write([]byte("hello"))
+	if err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+
+	if n != 5 {
+		t.Errorf("Write returned n = %d, want 5", n)
+	}
+
+	n, err = h.Write([]byte(" world"))
+	if err != nil {
+		t.Fatalf("second Write returned error: %v", err)
+	}
+
+	if n != 6 {
+		t.Errorf("second Write returned n = %d, want 6", n)
+	}
+
+	sum := h.Sum(nil)
+
+	if len(sum) != 8 {
+		t.Fatalf("Sum returned %d bytes, want 8", len(sum))
+	}
+
+	if got := binary.BigEndian.Uint64(sum); got != 11 {
+		t.Errorf("Sum encodes length %d, want 11 (5 + 6)", got)
+	}
+
+	// Sum(b) prefix-preservation is intentionally not tested here:
+	// the current LengthHasher.Sum implementation overwrites b
+	// rather than appending to it, violating the hash.Hash
+	// contract. All current callers pass nil so the bug is latent.
+	// Add a prefix-preservation case once the impl is fixed (see
+	// the entry in .claude/TODO.md).
+
+	h.Reset()
+
+	sumAfterReset := h.Sum(nil)
+
+	if got := binary.BigEndian.Uint64(sumAfterReset); got != 0 {
+		t.Errorf("Sum after Reset encodes length %d, want 0", got)
+	}
+}

--- a/core/index_test.go
+++ b/core/index_test.go
@@ -1,0 +1,263 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// newTestIndex builds an Index rooted at packRoot with no files.
+// Tests can populate Files directly before exercising methods.
+func newTestIndex(packRoot string) Index {
+	return Index{
+		HashFormat: "sha256",
+		Files:      IndexFiles{},
+		indexFile:  filepath.Join(packRoot, "index.toml"),
+		packRoot:   packRoot,
+	}
+}
+
+func TestResolveIndexPath(t *testing.T) {
+	in := newTestIndex(filepath.Join("some", "pack"))
+
+	// Index paths are stored forward-slashed; ResolveIndexPath converts
+	// to OS-native and joins with packRoot.
+	got := in.ResolveIndexPath("mods/sodium.pw.toml")
+	want := filepath.Join("some", "pack", "mods", "sodium.pw.toml")
+
+	if got != want {
+		t.Errorf("ResolveIndexPath = %q, want %q", got, want)
+	}
+}
+
+func TestRelIndexPath(t *testing.T) {
+	root := filepath.Join("some", "pack")
+	in := newTestIndex(root)
+
+	got, err := in.RelIndexPath(filepath.Join(root, "mods", "sodium.pw.toml"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "mods/sodium.pw.toml" {
+		t.Errorf("RelIndexPath = %q, want %q", got, "mods/sodium.pw.toml")
+	}
+}
+
+func TestFindMod(t *testing.T) {
+	root := filepath.Join("some", "pack")
+	in := newTestIndex(root)
+	in.Files["mods/sodium.pw.toml"] = &indexFile{File: "mods/sodium.pw.toml", MetaFile: true, fileFound: true}
+	in.Files["mods/iris.pw.toml"] = &indexFile{File: "mods/iris.pw.toml", MetaFile: true, fileFound: true}
+	in.Files["overrides/config.txt"] = &indexFile{File: "overrides/config.txt", fileFound: true}
+
+	t.Run("finds a metafile by slug", func(t *testing.T) {
+		got, ok := in.FindMod("sodium")
+		if !ok {
+			t.Fatal("expected to find sodium")
+		}
+
+		want := filepath.Join(root, "mods", "sodium.pw.toml")
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("misses unknown slug", func(t *testing.T) {
+		if _, ok := in.FindMod("does-not-exist"); ok {
+			t.Error("expected miss for unknown slug")
+		}
+	})
+
+	t.Run("skips non-metafile entries even if name matches", func(t *testing.T) {
+		// "config" would match overrides/config.txt's filename minus
+		// extension, but it is not a metafile and so should not be
+		// returned.
+		if _, ok := in.FindMod("config"); ok {
+			t.Error("expected miss for non-metafile entry")
+		}
+	})
+}
+
+func TestRemoveFile(t *testing.T) {
+	root := filepath.Join("some", "pack")
+	in := newTestIndex(root)
+	in.Files["mods/sodium.pw.toml"] = &indexFile{File: "mods/sodium.pw.toml"}
+
+	err := in.RemoveFile(filepath.Join(root, "mods", "sodium.pw.toml"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, present := in.Files["mods/sodium.pw.toml"]; present {
+		t.Error("entry was not removed")
+	}
+}
+
+func TestRefreshFileWithHash(t *testing.T) {
+	root := filepath.Join("some", "pack")
+	in := newTestIndex(root)
+
+	err := in.RefreshFileWithHash(
+		filepath.Join(root, "mods", "sodium.pw.toml"),
+		"sha256", "abc123", true,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	holder, ok := in.Files["mods/sodium.pw.toml"]
+	if !ok {
+		t.Fatal("entry was not created")
+	}
+
+	if !holder.IsMetaFile() {
+		t.Error("entry should be marked as metafile")
+	}
+
+	f := holder.(*indexFile)
+	// updateFileHashGiven blanks the format when it matches the index hash format.
+	if f.Hash != "abc123" || f.HashFormat != "" {
+		t.Errorf("got hash=%q format=%q, want hash=abc123 format=\"\"", f.Hash, f.HashFormat)
+	}
+}
+
+func TestLoadIndex_WriteRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	indexPath := filepath.Join(dir, "index.toml")
+
+	original := Index{
+		HashFormat: "sha256",
+		Files: IndexFiles{
+			"mods/sodium.pw.toml": &indexFile{
+				File:     "mods/sodium.pw.toml",
+				Hash:     "abc123",
+				MetaFile: true,
+			},
+			"mods/iris.pw.toml": &indexFile{
+				File:     "mods/iris.pw.toml",
+				Hash:     "def456",
+				MetaFile: true,
+			},
+			"overrides/config.txt": &indexFile{
+				File:       "overrides/config.txt",
+				Hash:       "ghi789",
+				HashFormat: "md5",
+			},
+		},
+		indexFile: indexPath,
+		packRoot:  dir,
+	}
+
+	if err := original.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	loaded, err := LoadIndex(indexPath)
+	if err != nil {
+		t.Fatalf("LoadIndex: %v", err)
+	}
+
+	if loaded.HashFormat != "sha256" {
+		t.Errorf("HashFormat = %q, want sha256", loaded.HashFormat)
+	}
+
+	if len(loaded.Files) != 3 {
+		t.Fatalf("Files count = %d, want 3", len(loaded.Files))
+	}
+
+	checkEntry := func(path, wantHash, wantFormat string, wantMeta bool) {
+		t.Helper()
+
+		holder, ok := loaded.Files[path]
+		if !ok {
+			t.Errorf("entry %q missing from loaded index", path)
+			return
+		}
+
+		f, ok := holder.(*indexFile)
+		if !ok {
+			t.Errorf("entry %q has unexpected holder type %T", path, holder)
+			return
+		}
+
+		if f.Hash != wantHash {
+			t.Errorf("entry %q hash = %q, want %q", path, f.Hash, wantHash)
+		}
+
+		if f.HashFormat != wantFormat {
+			t.Errorf("entry %q hashFormat = %q, want %q", path, f.HashFormat, wantFormat)
+		}
+
+		if f.MetaFile != wantMeta {
+			t.Errorf("entry %q metafile = %v, want %v", path, f.MetaFile, wantMeta)
+		}
+	}
+
+	// Metafiles inherit the index's HashFormat (sha256) and so the
+	// per-entry hash-format field is empty in the file representation.
+	checkEntry("mods/sodium.pw.toml", "abc123", "", true)
+	checkEntry("mods/iris.pw.toml", "def456", "", true)
+	// Non-default hash format (md5) is preserved per-entry.
+	checkEntry("overrides/config.txt", "ghi789", "md5", false)
+}
+
+func TestLoadIndex_DefaultsHashFormat(t *testing.T) {
+	// If hash-format is omitted, LoadIndex should default to sha256.
+	dir := t.TempDir()
+	indexPath := filepath.Join(dir, "index.toml")
+
+	contents := `[[files]]
+file = "mods/sodium.pw.toml"
+hash = "abc"
+metafile = true
+`
+	if err := os.WriteFile(indexPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	loaded, err := LoadIndex(indexPath)
+	if err != nil {
+		t.Fatalf("LoadIndex: %v", err)
+	}
+
+	if loaded.HashFormat != "sha256" {
+		t.Errorf("HashFormat = %q, want sha256 (default)", loaded.HashFormat)
+	}
+}
+
+func TestLoadIndex_MultipleAliasRoundTrip(t *testing.T) {
+	// Two file entries with the same path but different aliases should
+	// coalesce into an indexFileMultipleAlias on load.
+	dir := t.TempDir()
+	indexPath := filepath.Join(dir, "index.toml")
+
+	contents := `hash-format = "sha256"
+
+[[files]]
+file = "mods/dual.jar"
+hash = "h1"
+
+[[files]]
+file = "mods/dual.jar"
+hash = "h2"
+alias = "alt/dual.jar"
+`
+	if err := os.WriteFile(indexPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	loaded, err := LoadIndex(indexPath)
+	if err != nil {
+		t.Fatalf("LoadIndex: %v", err)
+	}
+
+	holder, ok := loaded.Files["mods/dual.jar"]
+	if !ok {
+		t.Fatal("mods/dual.jar missing from loaded index")
+	}
+
+	if _, ok := holder.(*indexFileMultipleAlias); !ok {
+		t.Errorf("expected *indexFileMultipleAlias holder, got %T", holder)
+	}
+}

--- a/core/indexfiles_test.go
+++ b/core/indexfiles_test.go
@@ -1,0 +1,164 @@
+package core
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestIndexFileStateMachine(t *testing.T) {
+	var f indexFile
+
+	if f.IsMetaFile() {
+		t.Error("zero indexFile should not be a metafile")
+	}
+
+	if f.markedFound() {
+		t.Error("zero indexFile should not be markedFound")
+	}
+
+	f.markFound()
+	if !f.markedFound() {
+		t.Error("after markFound, markedFound should be true")
+	}
+
+	f.markMetaFile()
+	if !f.IsMetaFile() {
+		t.Error("after markMetaFile, IsMetaFile should be true")
+	}
+
+	f.updateHash("deadbeef", "sha256")
+	if f.Hash != "deadbeef" || f.HashFormat != "sha256" {
+		t.Errorf("updateHash didn't set fields: got (%q, %q)", f.Hash, f.HashFormat)
+	}
+}
+
+func TestIndexFileMultipleAliasStateMachine(t *testing.T) {
+	m := indexFileMultipleAlias{
+		"a": {File: "mods/x.jar"},
+		"b": {File: "mods/x.jar", Alias: "alt/x.jar"},
+	}
+
+	if m.IsMetaFile() {
+		t.Error("expected IsMetaFile=false before markMetaFile")
+	}
+
+	if m.markedFound() {
+		t.Error("expected markedFound=false before markFound")
+	}
+
+	m.markFound()
+	if !m.markedFound() {
+		t.Error("expected markedFound=true after markFound")
+	}
+
+	m.markMetaFile()
+	if !m.IsMetaFile() {
+		t.Error("expected IsMetaFile=true after markMetaFile")
+	}
+
+	m.updateHash("deadbeef", "sha256")
+	for k, v := range m {
+		if v.Hash != "deadbeef" || v.HashFormat != "sha256" {
+			t.Errorf("entry %q has hash (%q, %q), want (deadbeef, sha256)", k, v.Hash, v.HashFormat)
+		}
+	}
+}
+
+func TestUpdateFileEntry(t *testing.T) {
+	t.Run("adds entry when path absent", func(t *testing.T) {
+		var files IndexFiles
+		files.updateFileEntry("mods/sodium.pw.toml", "sha256", "abc", true)
+
+		holder, ok := files["mods/sodium.pw.toml"]
+		if !ok {
+			t.Fatal("entry was not added")
+		}
+
+		if !holder.IsMetaFile() || !holder.markedFound() {
+			t.Error("new entry should be marked metafile + found")
+		}
+	})
+
+	t.Run("updates hash on existing entry", func(t *testing.T) {
+		files := IndexFiles{}
+		files.updateFileEntry("mods/x.jar", "sha256", "first", false)
+		files.updateFileEntry("mods/x.jar", "sha256", "second", false)
+
+		f := files["mods/x.jar"].(*indexFile)
+		if f.Hash != "second" {
+			t.Errorf("hash = %q, want %q", f.Hash, "second")
+		}
+	})
+
+	t.Run("never un-sets metafile flag on existing entry", func(t *testing.T) {
+		files := IndexFiles{}
+		files.updateFileEntry("mods/x.pw.toml", "sha256", "abc", true)
+		// Second update without markAsMetaFile should not clear the flag.
+		files.updateFileEntry("mods/x.pw.toml", "sha256", "def", false)
+
+		if !files["mods/x.pw.toml"].IsMetaFile() {
+			t.Error("IsMetaFile flag was cleared by a non-metafile update")
+		}
+	})
+}
+
+func TestIndexFilesTomlRoundTrip(t *testing.T) {
+	t.Run("single file round-trips", func(t *testing.T) {
+		rep := indexFilesTomlRepresentation{
+			{File: "mods/sodium.pw.toml", Hash: "abc", HashFormat: "sha256", MetaFile: true},
+		}
+
+		mem := rep.toMemoryRep()
+		back := mem.toTomlRep()
+
+		if !reflect.DeepEqual([]indexFile(rep), []indexFile(back)) {
+			t.Errorf("round-trip mismatch:\n  before: %+v\n   after: %+v", rep, back)
+		}
+	})
+
+	t.Run("multiple-alias entries are coalesced and re-expanded", func(t *testing.T) {
+		rep := indexFilesTomlRepresentation{
+			{File: "mods/x.jar", Alias: "", Hash: "a", HashFormat: "sha256"},
+			{File: "mods/x.jar", Alias: "alt/x.jar", Hash: "b", HashFormat: "sha256"},
+		}
+
+		mem := rep.toMemoryRep()
+
+		holder, ok := mem["mods/x.jar"]
+		if !ok {
+			t.Fatal("mods/x.jar missing from memory rep")
+		}
+
+		if _, ok := holder.(*indexFileMultipleAlias); !ok {
+			t.Errorf("expected *indexFileMultipleAlias holder, got %T", holder)
+		}
+
+		back := mem.toTomlRep()
+		if len(back) != 2 {
+			t.Fatalf("toTomlRep returned %d entries, want 2", len(back))
+		}
+	})
+
+	t.Run("toTomlRep sorts by file then alias", func(t *testing.T) {
+		rep := indexFilesTomlRepresentation{
+			{File: "z.jar", Hash: "1", HashFormat: "sha256"},
+			{File: "a.jar", Alias: "b", Hash: "2", HashFormat: "sha256"},
+			{File: "a.jar", Alias: "a", Hash: "3", HashFormat: "sha256"},
+		}
+
+		mem := rep.toMemoryRep()
+		out := mem.toTomlRep()
+
+		if out[0].File != "a.jar" || out[0].Alias != "a" {
+			t.Errorf("first entry: got %+v", out[0])
+		}
+
+		if out[1].File != "a.jar" || out[1].Alias != "b" {
+			t.Errorf("second entry: got %+v", out[1])
+		}
+
+		if out[2].File != "z.jar" {
+			t.Errorf("third entry: got %+v", out[2])
+		}
+	})
+}

--- a/core/mod_test.go
+++ b/core/mod_test.go
@@ -1,0 +1,161 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSlugifyName(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"already-a-slug", "sodium", "sodium"},
+		{"lowercases", "Sodium", "sodium"},
+		{"replaces spaces with dashes", "Iris Shaders", "iris-shaders"},
+		{"strips parenthesized suffix", "A Man With Plushies (AMWPlushies)", "a-man-with-plushies"},
+		{"strips ' - subtitle' suffix", "Mod Name - Forge Edition", "mod-name"},
+		{"collapses runs of dashes", "Foo - - Bar", "foo"},
+		{"removes leading and trailing dashes", "  spaced name  ", "spaced-name"},
+		{"keeps digits", "BetterF3 v4", "betterf3-v4"},
+		{"drops non-alphanumeric characters", "Re:Source Pack!", "re-source-pack"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SlugifyName(tc.input)
+
+			if got != tc.want {
+				t.Errorf("SlugifyName(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestModPathAccessors(t *testing.T) {
+	var m Mod
+
+	got := m.SetMetaPath(filepath.Join("mods", "sodium.pw.toml"))
+	want := filepath.Join("mods", "sodium.pw.toml")
+
+	if got != want {
+		t.Errorf("SetMetaPath returned %q, want %q", got, want)
+	}
+
+	if got := m.GetFilePath(); got != want {
+		t.Errorf("GetFilePath = %q, want %q", got, want)
+	}
+
+	m.FileName = "sodium-fabric-mc1.20.1-0.5.3.jar"
+	gotDest := m.GetDestFilePath()
+	wantDest := filepath.Join("mods", "sodium-fabric-mc1.20.1-0.5.3.jar")
+
+	if gotDest != wantDest {
+		t.Errorf("GetDestFilePath = %q, want %q", gotDest, wantDest)
+	}
+}
+
+func TestGetParsedUpdateData(t *testing.T) {
+	m := Mod{
+		updateData: map[string]interface{}{
+			"curseforge": map[string]int{"file-id": 12345},
+		},
+	}
+
+	got, ok := m.GetParsedUpdateData("curseforge")
+	if !ok {
+		t.Fatalf("expected GetParsedUpdateData(curseforge) to find entry")
+	}
+
+	if m, isMap := got.(map[string]int); !isMap || m["file-id"] != 12345 {
+		t.Errorf("got %#v, want map with file-id=12345", got)
+	}
+
+	if _, ok := m.GetParsedUpdateData("modrinth"); ok {
+		t.Errorf("expected miss for modrinth, got hit")
+	}
+}
+
+func TestLoadMod_WriteRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	modPath := filepath.Join(dir, "sodium.pw.toml")
+
+	original := Mod{
+		Name:     "Sodium",
+		FileName: "sodium-fabric-mc1.20.1-0.5.3.jar",
+		Side:     "client",
+		Pin:      true,
+		Download: ModDownload{
+			URL:        "https://cdn.modrinth.com/data/AANobbMI/versions/sodium-fabric.jar",
+			HashFormat: "sha512",
+			Hash:       "0123456789abcdef",
+			Mode:       "",
+		},
+	}
+
+	original.SetMetaPath(modPath)
+
+	hashFormat, hashString, err := original.Write()
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if hashFormat != "sha256" {
+		t.Errorf("Write returned hashFormat = %q, want sha256", hashFormat)
+	}
+
+	if hashString == "" {
+		t.Error("Write returned empty hash string")
+	}
+
+	loaded, err := LoadMod(modPath)
+	if err != nil {
+		t.Fatalf("LoadMod: %v", err)
+	}
+
+	if loaded.Name != original.Name {
+		t.Errorf("Name = %q, want %q", loaded.Name, original.Name)
+	}
+
+	if loaded.FileName != original.FileName {
+		t.Errorf("FileName = %q, want %q", loaded.FileName, original.FileName)
+	}
+
+	if loaded.Side != original.Side {
+		t.Errorf("Side = %q, want %q", loaded.Side, original.Side)
+	}
+
+	if loaded.Pin != original.Pin {
+		t.Errorf("Pin = %v, want %v", loaded.Pin, original.Pin)
+	}
+
+	if loaded.Download != original.Download {
+		t.Errorf("Download = %+v, want %+v", loaded.Download, original.Download)
+	}
+
+	// metaFile is set during LoadMod from the supplied path.
+	if loaded.GetFilePath() != modPath {
+		t.Errorf("GetFilePath = %q, want %q", loaded.GetFilePath(), modPath)
+	}
+}
+
+func TestMod_Write_CreatesContainingDirectory(t *testing.T) {
+	// Write attempts MkdirAll if the parent directory is missing.
+	// Verify a mod whose metaFile points at a nested path that does
+	// not yet exist still succeeds.
+	dir := t.TempDir()
+	nestedPath := filepath.Join(dir, "deep", "nested", "mod.pw.toml")
+
+	m := Mod{Name: "Test", FileName: "test.jar"}
+	m.SetMetaPath(nestedPath)
+
+	if _, _, err := m.Write(); err != nil {
+		t.Fatalf("Write into a non-existent parent directory failed: %v", err)
+	}
+
+	if _, err := os.Stat(nestedPath); err != nil {
+		t.Errorf("expected file at %q, stat error: %v", nestedPath, err)
+	}
+}

--- a/core/pack_test.go
+++ b/core/pack_test.go
@@ -1,0 +1,295 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestGetMCVersion(t *testing.T) {
+	t.Run("returns version when set", func(t *testing.T) {
+		p := Pack{Versions: map[string]string{"minecraft": "1.20.1"}}
+
+		got, err := p.GetMCVersion()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got != "1.20.1" {
+			t.Errorf("got %q, want %q", got, "1.20.1")
+		}
+	})
+
+	t.Run("returns error when minecraft version absent", func(t *testing.T) {
+		p := Pack{Versions: map[string]string{"fabric": "0.15.0"}}
+
+		if _, err := p.GetMCVersion(); err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+}
+
+func TestGetSupportedMCVersions(t *testing.T) {
+	// Use a clean viper state for the duration of this test.
+	t.Cleanup(func() { viper.Set("acceptable-game-versions", nil) })
+	viper.Set("acceptable-game-versions", nil)
+
+	t.Run("returns just the configured version when no extras", func(t *testing.T) {
+		p := Pack{Versions: map[string]string{"minecraft": "1.20.1"}}
+
+		got, err := p.GetSupportedMCVersions()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, []string{"1.20.1"}) {
+			t.Errorf("got %v, want [1.20.1]", got)
+		}
+	})
+
+	t.Run("appends acceptable-game-versions and dedups so main version is last", func(t *testing.T) {
+		viper.Set("acceptable-game-versions", []string{"1.19.4", "1.20.1", "1.20"})
+		p := Pack{Versions: map[string]string{"minecraft": "1.20.1"}}
+
+		got, err := p.GetSupportedMCVersions()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// 1.20.1 appears in extras AND as main; the dedup logic keeps the
+		// later occurrence, so the main version ends up last.
+		want := []string{"1.19.4", "1.20", "1.20.1"}
+
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("returns error when minecraft version absent", func(t *testing.T) {
+		viper.Set("acceptable-game-versions", nil)
+		p := Pack{Versions: map[string]string{}}
+
+		if _, err := p.GetSupportedMCVersions(); err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+}
+
+func TestGetPackName(t *testing.T) {
+	cases := []struct {
+		name    string
+		pack    Pack
+		want    string
+	}{
+		{"empty name falls back to export", Pack{}, "export"},
+		{"name only", Pack{Name: "MyPack"}, "MyPack"},
+		{"name plus version", Pack{Name: "MyPack", Version: "1.0"}, "MyPack-1.0"},
+		{"version without name still falls back", Pack{Version: "1.0"}, "export"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.pack.GetPackName(); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetCompatibleLoaders(t *testing.T) {
+	cases := []struct {
+		name     string
+		versions map[string]string
+		want     []string
+	}{
+		{"quilt implies fabric compat", map[string]string{"quilt": "1"}, []string{"quilt", "fabric"}},
+		{"fabric alone", map[string]string{"fabric": "1"}, []string{"fabric"}},
+		{"neoforge implies forge compat", map[string]string{"neoforge": "1"}, []string{"neoforge", "forge"}},
+		{"forge alone", map[string]string{"forge": "1"}, []string{"forge"}},
+		{"quilt + neoforge", map[string]string{"quilt": "1", "neoforge": "1"}, []string{"quilt", "fabric", "neoforge", "forge"}},
+		{"none", map[string]string{}, nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := Pack{Versions: tc.versions}
+
+			got := p.GetCompatibleLoaders()
+
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetLoaders(t *testing.T) {
+	cases := []struct {
+		name     string
+		versions map[string]string
+		want     []string
+	}{
+		{"single fabric", map[string]string{"fabric": "1"}, []string{"fabric"}},
+		{"quilt does NOT imply fabric here", map[string]string{"quilt": "1"}, []string{"quilt"}},
+		{"all four declared", map[string]string{"quilt": "1", "fabric": "1", "neoforge": "1", "forge": "1"}, []string{"quilt", "fabric", "neoforge", "forge"}},
+		{"none", map[string]string{}, nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := Pack{Versions: tc.versions}
+
+			got := p.GetLoaders()
+
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadPack_WriteRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	packPath := filepath.Join(dir, "pack.toml")
+
+	t.Cleanup(func() { viper.Set("pack-file", "") })
+	viper.Set("pack-file", packPath)
+
+	original := Pack{
+		Name:        "TestPack",
+		Author:      "tester",
+		Version:     "1.0.0",
+		Description: "A pack used by TestLoadPack_WriteRoundTrip",
+		PackFormat:  CurrentPackFormat,
+		Versions: map[string]string{
+			"minecraft": "1.20.1",
+			"fabric":    "0.15.0",
+		},
+	}
+
+	original.Index.File = "index.toml"
+	original.Index.HashFormat = "sha256"
+	original.Index.Hash = "deadbeef"
+
+	if err := original.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	loaded, err := LoadPack()
+	if err != nil {
+		t.Fatalf("LoadPack: %v", err)
+	}
+
+	if loaded.Name != original.Name {
+		t.Errorf("Name = %q, want %q", loaded.Name, original.Name)
+	}
+
+	if loaded.Author != original.Author {
+		t.Errorf("Author = %q, want %q", loaded.Author, original.Author)
+	}
+
+	if loaded.Version != original.Version {
+		t.Errorf("Version = %q, want %q", loaded.Version, original.Version)
+	}
+
+	if loaded.PackFormat != original.PackFormat {
+		t.Errorf("PackFormat = %q, want %q", loaded.PackFormat, original.PackFormat)
+	}
+
+	if loaded.Index.File != original.Index.File {
+		t.Errorf("Index.File = %q, want %q", loaded.Index.File, original.Index.File)
+	}
+
+	if loaded.Index.Hash != original.Index.Hash {
+		t.Errorf("Index.Hash = %q, want %q", loaded.Index.Hash, original.Index.Hash)
+	}
+
+	if !reflect.DeepEqual(loaded.Versions, original.Versions) {
+		t.Errorf("Versions = %v, want %v", loaded.Versions, original.Versions)
+	}
+}
+
+func TestLoadPack_AutoMigratesOldFormat(t *testing.T) {
+	dir := t.TempDir()
+	packPath := filepath.Join(dir, "pack.toml")
+
+	t.Cleanup(func() { viper.Set("pack-file", "") })
+	viper.Set("pack-file", packPath)
+
+	// Pack written with the older packwiz:1.0.0 format should be
+	// auto-migrated to 1.1.0 on load.
+	original := Pack{
+		Name:       "OldPack",
+		PackFormat: "packwiz:1.0.0",
+		Versions:   map[string]string{"minecraft": "1.20.1"},
+	}
+	original.Index.File = "index.toml"
+	original.Index.HashFormat = "sha256"
+
+	if err := original.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	loaded, err := LoadPack()
+	if err != nil {
+		t.Fatalf("LoadPack: %v", err)
+	}
+
+	if loaded.PackFormat != "packwiz:1.1.0" {
+		t.Errorf("PackFormat = %q, want packwiz:1.1.0 (migrated)", loaded.PackFormat)
+	}
+}
+
+func TestLoadPack_DefaultsIndexFile(t *testing.T) {
+	dir := t.TempDir()
+	packPath := filepath.Join(dir, "pack.toml")
+
+	t.Cleanup(func() { viper.Set("pack-file", "") })
+	viper.Set("pack-file", packPath)
+
+	original := Pack{
+		Name:       "DefaultIndexPack",
+		PackFormat: CurrentPackFormat,
+		Versions:   map[string]string{"minecraft": "1.20.1"},
+	}
+
+	if err := original.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	loaded, err := LoadPack()
+	if err != nil {
+		t.Fatalf("LoadPack: %v", err)
+	}
+
+	if loaded.Index.File != "index.toml" {
+		t.Errorf("Index.File = %q, want index.toml (default)", loaded.Index.File)
+	}
+}
+
+func TestLoadPack_RejectsNonPackwizFormat(t *testing.T) {
+	dir := t.TempDir()
+	packPath := filepath.Join(dir, "pack.toml")
+
+	t.Cleanup(func() { viper.Set("pack-file", "") })
+	viper.Set("pack-file", packPath)
+
+	bad := `name = "Bad"
+pack-format = "modpack:1.0.0"
+[index]
+file = "index.toml"
+hash-format = "sha256"
+[versions]
+minecraft = "1.20.1"
+`
+	if err := os.WriteFile(packPath, []byte(bad), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if _, err := LoadPack(); err == nil {
+		t.Error("expected error for non-packwiz pack-format, got nil")
+	}
+}

--- a/core/storeutil_test.go
+++ b/core/storeutil_test.go
@@ -1,0 +1,96 @@
+package core
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestGetPackwizLocalCache(t *testing.T) {
+	// Should always return a path ending in "packwiz" under the user's
+	// cache dir. We don't pin the prefix — just verify the suffix and
+	// the no-error contract.
+	got, err := GetPackwizLocalCache()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if filepath.Base(got) != "packwiz" {
+		t.Errorf("path %q should end in packwiz", got)
+	}
+}
+
+func TestGetPackwizLocalStore_LinuxXDG(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("XDG_DATA_HOME branch is linux-only")
+	}
+
+	t.Setenv("XDG_DATA_HOME", "/tmp/test-xdg-data")
+
+	got, err := GetPackwizLocalStore()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := filepath.Join("/tmp/test-xdg-data", "packwiz")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestGetPackwizInstallBinFile(t *testing.T) {
+	got, err := GetPackwizInstallBinFile()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The leaf should be the platform-appropriate executable name.
+	var wantLeaf string
+	if runtime.GOOS == "windows" {
+		wantLeaf = "packwiz.exe"
+	} else {
+		wantLeaf = "packwiz"
+	}
+
+	if filepath.Base(got) != wantLeaf {
+		t.Errorf("leaf of %q = %q, want %q", got, filepath.Base(got), wantLeaf)
+	}
+
+	if !strings.Contains(got, "bin") {
+		t.Errorf("path %q should contain a 'bin' segment", got)
+	}
+}
+
+func TestGetPackwizCache(t *testing.T) {
+	t.Cleanup(func() { viper.Set("cache.directory", nil) })
+
+	t.Run("returns configured cache.directory when set", func(t *testing.T) {
+		viper.Set("cache.directory", "/tmp/configured-cache")
+
+		got, err := GetPackwizCache()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got != "/tmp/configured-cache" {
+			t.Errorf("got %q, want /tmp/configured-cache", got)
+		}
+	})
+
+	t.Run("falls back to local cache when unset", func(t *testing.T) {
+		viper.Set("cache.directory", "")
+
+		got, err := GetPackwizCache()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Should end in packwiz/cache.
+		if filepath.Base(got) != "cache" || filepath.Base(filepath.Dir(got)) != "packwiz" {
+			t.Errorf("fallback path %q should end in packwiz/cache", got)
+		}
+	})
+}

--- a/core/testdata/README.md
+++ b/core/testdata/README.md
@@ -1,0 +1,22 @@
+# Test fixtures
+
+## example-pack/
+
+Verbatim copy of [packwiz/packwiz-example-pack][upstream] at tag `v1`,
+minus files irrelevant to the tests (`.gitattributes`, `.gitignore`,
+`.packwizignore`, `README.md`).
+
+Used by `example_pack_test.go` for round-trip tests against a real
+packwiz pack: `Pack.UpdateIndexHash`, `Index.LoadAllMods`,
+`Index.Refresh`.
+
+The vendored pack is **CC0 1.0**, public domain (see
+`example-pack/LICENSE`). The upstream README explicitly invites
+copying for derivative use.
+
+[upstream]: https://github.com/packwiz/packwiz-example-pack/tree/v1
+
+Do not modify the vendored files — `TestPack_UpdateIndexHash_FromExamplePack`
+pins the index hash recorded in the upstream `pack.toml`. Refreshing the
+fixture should be done by re-vendoring from upstream rather than
+hand-editing.

--- a/core/testdata/example-pack/LICENSE
+++ b/core/testdata/example-pack/LICENSE
@@ -1,0 +1,116 @@
+CC0 1.0 Universal
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator and
+subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for the
+purpose of contributing to a commons of creative, cultural and scientific
+works ("Commons") that the public can reliably and without fear of later
+claims of infringement build upon, modify, incorporate in other works, reuse
+and redistribute as freely as possible in any form whatsoever and for any
+purposes, including without limitation commercial purposes. These owners may
+contribute to the Commons to promote the ideal of a free culture and the
+further production of creative, cultural and scientific works, or to gain
+reputation or greater distribution for their Work in part through the use and
+efforts of others.
+
+For these and/or other purposes and motivations, and without any expectation
+of additional consideration or compensation, the person associating CC0 with a
+Work (the "Affirmer"), to the extent that he or she is an owner of Copyright
+and Related Rights in the Work, voluntarily elects to apply CC0 to the Work
+and publicly distribute the Work under its terms, with knowledge of his or her
+Copyright and Related Rights in the Work and the meaning and intended legal
+effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not limited
+to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display, communicate,
+  and translate a Work;
+
+  ii. moral rights retained by the original author(s) and/or performer(s);
+
+  iii. publicity and privacy rights pertaining to a person's image or likeness
+  depicted in a Work;
+
+  iv. rights protecting against unfair competition in regards to a Work,
+  subject to the limitations in paragraph 4(a), below;
+
+  v. rights protecting the extraction, dissemination, use and reuse of data in
+  a Work;
+
+  vi. database rights (such as those arising under Directive 96/9/EC of the
+  European Parliament and of the Council of 11 March 1996 on the legal
+  protection of databases, and under any national implementation thereof,
+  including any amended or successor version of such directive); and
+
+  vii. other similar, equivalent or corresponding rights throughout the world
+  based on applicable law or treaty, and any national implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention of,
+applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and
+unconditionally waives, abandons, and surrenders all of Affirmer's Copyright
+and Related Rights and associated claims and causes of action, whether now
+known or unknown (including existing as well as future claims and causes of
+action), in the Work (i) in all territories worldwide, (ii) for the maximum
+duration provided by applicable law or treaty (including future time
+extensions), (iii) in any current or future medium and for any number of
+copies, and (iv) for any purpose whatsoever, including without limitation
+commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes
+the Waiver for the benefit of each member of the public at large and to the
+detriment of Affirmer's heirs and successors, fully intending that such Waiver
+shall not be subject to revocation, rescission, cancellation, termination, or
+any other legal or equitable action to disrupt the quiet enjoyment of the Work
+by the public as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason be
+judged legally invalid or ineffective under applicable law, then the Waiver
+shall be preserved to the maximum extent permitted taking into account
+Affirmer's express Statement of Purpose. In addition, to the extent the Waiver
+is so judged Affirmer hereby grants to each affected person a royalty-free,
+non transferable, non sublicensable, non exclusive, irrevocable and
+unconditional license to exercise Affirmer's Copyright and Related Rights in
+the Work (i) in all territories worldwide, (ii) for the maximum duration
+provided by applicable law or treaty (including future time extensions), (iii)
+in any current or future medium and for any number of copies, and (iv) for any
+purpose whatsoever, including without limitation commercial, advertising or
+promotional purposes (the "License"). The License shall be deemed effective as
+of the date CC0 was applied by Affirmer to the Work. Should any part of the
+License for any reason be judged legally invalid or ineffective under
+applicable law, such partial invalidity or ineffectiveness shall not
+invalidate the remainder of the License, and in such case Affirmer hereby
+affirms that he or she will not (i) exercise any of his or her remaining
+Copyright and Related Rights in the Work or (ii) assert any associated claims
+and causes of action with respect to the Work, in either case contrary to
+Affirmer's express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+  a. No trademark or patent rights held by Affirmer are waived, abandoned,
+  surrendered, licensed or otherwise affected by this document.
+
+  b. Affirmer offers the Work as-is and makes no representations or warranties
+  of any kind concerning the Work, express, implied, statutory or otherwise,
+  including without limitation warranties of title, merchantability, fitness
+  for a particular purpose, non infringement, or the absence of latent or
+  other defects, accuracy, or the present or absence of errors, whether or not
+  discoverable, all to the greatest extent permissible under applicable law.
+
+  c. Affirmer disclaims responsibility for clearing rights of other persons
+  that may apply to the Work or any use thereof, including without limitation
+  any person's Copyright and Related Rights in the Work. Further, Affirmer
+  disclaims responsibility for obtaining any necessary consents, permissions
+  or other rights required for any use of the Work.
+
+  d. Affirmer understands and acknowledges that Creative Commons is not a
+  party to this document and has no duty or obligation with respect to this
+  CC0 or use of the Work.
+
+For more information, please see
+<http://creativecommons.org/publicdomain/zero/1.0/>

--- a/core/testdata/example-pack/index.toml
+++ b/core/testdata/example-pack/index.toml
@@ -1,0 +1,15 @@
+hash-format = "sha256"
+
+[[files]]
+file = "LICENSE"
+hash = "36ffd9dc085d529a7e60e1276d73ae5a030b020313e6c5408593a6ae2af39673"
+
+[[files]]
+file = "mods/borderless-mining.pw.toml"
+hash = "407fd025c6912135c7d40c238bb96fe05ea8172c403a100ed86f978fc8124c81"
+metafile = true
+
+[[files]]
+file = "mods/screenshot-to-clipboard-fabric.pw.toml"
+hash = "d580e87dd3fbea1d9bd98da604ff9ed7de782565e507a113031f0555763901aa"
+metafile = true

--- a/core/testdata/example-pack/mods/borderless-mining.pw.toml
+++ b/core/testdata/example-pack/mods/borderless-mining.pw.toml
@@ -1,0 +1,13 @@
+name = "Borderless Mining"
+filename = "borderless-mining-1.1.5+1.19.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/kYq5qkSL/versions/1.1.5+1.19/borderless-mining-1.1.5%2B1.19.jar"
+hash-format = "sha1"
+hash = "08f98e28057a0fbdb288c947b7871def4b18b176"
+
+[update]
+[update.modrinth]
+mod-id = "kYq5qkSL"
+version = "gqoXgtxO"

--- a/core/testdata/example-pack/mods/screenshot-to-clipboard-fabric.pw.toml
+++ b/core/testdata/example-pack/mods/screenshot-to-clipboard-fabric.pw.toml
@@ -1,0 +1,13 @@
+name = "Screenshot to Clipboard (Fabric)"
+filename = "screenshot-to-clipboard-1.0.9-fabric.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "39c55d7e0ebe4a7f626e0d4bc85b8d2bea353092"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 3643025
+project-id = 327154

--- a/core/testdata/example-pack/pack.toml
+++ b/core/testdata/example-pack/pack.toml
@@ -1,0 +1,13 @@
+name = "packwiz Example Pack"
+author = "comp500"
+version = "1.0.0"
+pack-format = "packwiz:1.1.0"
+
+[index]
+file = "index.toml"
+hash-format = "sha256"
+hash = "29bcf953b90081730cd8a32cc4d855ab6ad96685c3aeea6ed033dc4f04d390ac"
+
+[versions]
+minecraft = "1.19"
+quilt = "0.17.0"

--- a/core/urlutil_test.go
+++ b/core/urlutil_test.go
@@ -1,0 +1,37 @@
+package core
+
+import (
+	"testing"
+)
+
+func TestReencodeURL(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "plain URL passes through unchanged",
+			input: "https://example.com/path/file.jar",
+			want:  "https://example.com/path/file.jar",
+		},
+		{
+			name:  "square brackets are encoded to %5B and %5D",
+			input: "https://edge.forgecdn.net/files/123/456/mod[1.0].jar",
+			want:  "https://edge.forgecdn.net/files/123/456/mod%5B1.0%5D.jar",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ReencodeURL(tc.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != tc.want {
+				t.Errorf("ReencodeURL(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/core/versionutil_test.go
+++ b/core/versionutil_test.go
@@ -133,3 +133,107 @@ func TestNeoForge261snapshot6(t *testing.T) {
 	expectValid(t, "neoforge", "26.1-snapshot-6", "26.1.0.0-alpha.9+snapshot-6")
 	expectInvalid(t, "neoforge", "26.1-snapshot-6", "26.1.0.0-alpha.11+snapshot-7")
 }
+
+func TestHighestSliceIndex(t *testing.T) {
+	cases := []struct {
+		name   string
+		slice  []string
+		values []string
+		want   int
+	}{
+		{
+			name:   "no overlap returns -1",
+			slice:  []string{"1.19", "1.20"},
+			values: []string{"1.18"},
+			want:   -1,
+		},
+		{
+			name:   "single match returns its index",
+			slice:  []string{"1.19", "1.20"},
+			values: []string{"1.20"},
+			want:   1,
+		},
+		{
+			// values that don't exist in slice are ignored; the highest
+			// index of those that DO exist wins.
+			name:   "mix of present and absent values takes the highest present",
+			slice:  []string{"1.19", "1.20"},
+			values: []string{"1.20", "1.18"},
+			want:   1,
+		},
+		{
+			name:   "all present picks highest",
+			slice:  []string{"1.19", "1.20", "1.21"},
+			values: []string{"1.19", "1.20", "1.21"},
+			want:   2,
+		},
+		{
+			name:   "empty values returns -1",
+			slice:  []string{"1.19", "1.20"},
+			values: nil,
+			want:   -1,
+		},
+		{
+			name:   "empty slice returns -1",
+			slice:  nil,
+			values: []string{"1.19"},
+			want:   -1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HighestSliceIndex(tc.slice, tc.values); got != tc.want {
+				t.Errorf("HighestSliceIndex(%v, %v) = %d, want %d",
+					tc.slice, tc.values, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestVersionListQuery_WithQueryType(t *testing.T) {
+	// Builder method: copies the receiver, replaces QueryType, leaves
+	// Loader and McVersion intact. Verifies it doesn't mutate the
+	// original.
+	original := VersionListQuery{
+		Loader:    ModLoaderComponent{Name: "fabric", FriendlyName: "Fabric"},
+		McVersion: "1.20.1",
+		QueryType: Latest,
+	}
+
+	updated := original.WithQueryType(Recommended)
+
+	if updated.QueryType != Recommended {
+		t.Errorf("updated QueryType = %v, want Recommended", updated.QueryType)
+	}
+
+	if updated.Loader.Name != "fabric" || updated.McVersion != "1.20.1" {
+		t.Errorf("WithQueryType lost other fields: got %+v", updated)
+	}
+
+	if original.QueryType != Latest {
+		t.Errorf("WithQueryType mutated the receiver: original.QueryType = %v, want Latest", original.QueryType)
+	}
+}
+
+func TestComponentToFriendlyName(t *testing.T) {
+	cases := []struct {
+		name      string
+		component string
+		want      string
+	}{
+		{"minecraft is a hardcoded special case", "minecraft", "Minecraft"},
+		{"fabric maps to its FriendlyName", "fabric", "Fabric loader"},
+		{"neoforge maps to its FriendlyName", "neoforge", "NeoForge"},
+		{"forge maps to its FriendlyName", "forge", "Forge"},
+		{"unknown component returns input unchanged", "definitely-not-a-loader", "definitely-not-a-loader"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ComponentToFriendlyName(tc.component); got != tc.want {
+				t.Errorf("ComponentToFriendlyName(%q) = %q, want %q", tc.component, got, tc.want)
+			}
+		})
+	}
+}

--- a/curseforge/curseforge_test.go
+++ b/curseforge/curseforge_test.go
@@ -1,0 +1,767 @@
+package curseforge
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/packwiz/packwiz/core"
+	"github.com/spf13/viper"
+)
+
+// newTestCurseforgeMod writes a Mod TOML referencing the curseforge
+// update plugin, then loads it through core.LoadMod so the registered
+// cfUpdater parses the update map.
+func newTestCurseforgeMod(t *testing.T, name, filename string, projectID, fileID uint32) *core.Mod {
+	t.Helper()
+
+	dir := t.TempDir()
+	modPath := filepath.Join(dir, "test.pw.toml")
+
+	contents := fmt.Sprintf(`name = %q
+filename = %q
+
+[download]
+url = "https://example.com/file.jar"
+hash-format = "sha1"
+hash = "deadbeef"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+project-id = %d
+file-id = %d
+`, name, filename, projectID, fileID)
+
+	if err := os.WriteFile(modPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	mod, err := core.LoadMod(modPath)
+	if err != nil {
+		t.Fatalf("LoadMod: %v", err)
+	}
+
+	return &mod
+}
+
+func TestGetCurseforgeVersion(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain release passes through unchanged", "1.20.1", "1.20.1"},
+		{"pre-release suffix triggers -Snapshot", "1.18.1-pre1", "1.18.1-Snapshot"},
+		{"rc suffix triggers -Snapshot", "1.20-rc1", "1.20-Snapshot"},
+		{"22w24a maps to 1.19-Snapshot", "22w24a", "1.19-Snapshot"},
+		{"20w20a maps to 1.16-Snapshot per the snapshot table", "20w20a", "1.16-Snapshot"},
+		{"non-matching gibberish returns input unchanged", "definitely-not-a-version", "definitely-not-a-version"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := getCurseforgeVersion(tc.input); got != tc.want {
+				t.Errorf("getCurseforgeVersion(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetCurseforgeVersions(t *testing.T) {
+	got := getCurseforgeVersions([]string{"1.20.1", "1.18.1-pre1", "1.19.4"})
+	want := []string{"1.20.1", "1.18.1-Snapshot", "1.19.4"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	if got := getCurseforgeVersions(nil); len(got) != 0 {
+		t.Errorf("nil input should yield empty slice, got %v", got)
+	}
+}
+
+func TestParseSlugOrUrl(t *testing.T) {
+	cases := []struct {
+		name         string
+		input        string
+		wantGame     string
+		wantCategory string
+		wantSlug     string
+		wantFileID   uint32
+	}{
+		{
+			name:         "curseforge.com URL with category",
+			input:        "https://www.curseforge.com/minecraft/mc-mods/sodium",
+			wantGame:     "minecraft",
+			wantCategory: "mc-mods",
+			wantSlug:     "sodium",
+		},
+		{
+			name:         "curseforge.com URL with category and fileID",
+			input:        "https://www.curseforge.com/minecraft/mc-mods/sodium/files/4567890",
+			wantGame:     "minecraft",
+			wantCategory: "mc-mods",
+			wantSlug:     "sodium",
+			wantFileID:   4567890,
+		},
+		{
+			name:     "legacy minecraft.curseforge.com URL (no category)",
+			input:    "https://minecraft.curseforge.com/projects/sodium",
+			wantGame: "minecraft",
+			wantSlug: "sodium",
+		},
+		{
+			name:     "plain slug",
+			input:    "sodium",
+			wantSlug: "sodium",
+		},
+		{
+			// Trailing punctuation breaks all three regexes; the function
+			// returns zero values with no error.
+			name: "non-matching input returns zero values",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			game, category, slug, fileID, err := parseSlugOrUrl(tc.input)
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if game != tc.wantGame {
+				t.Errorf("game = %q, want %q", game, tc.wantGame)
+			}
+
+			if category != tc.wantCategory {
+				t.Errorf("category = %q, want %q", category, tc.wantCategory)
+			}
+
+			if slug != tc.wantSlug {
+				t.Errorf("slug = %q, want %q", slug, tc.wantSlug)
+			}
+
+			if fileID != tc.wantFileID {
+				t.Errorf("fileID = %d, want %d", fileID, tc.wantFileID)
+			}
+		})
+	}
+}
+
+func TestGetPathForFile(t *testing.T) {
+	t.Cleanup(func() {
+		viper.Set("meta-folder", "")
+		viper.Set("meta-folder-base", "")
+	})
+
+	t.Run("known game + class folder mapping", func(t *testing.T) {
+		viper.Set("meta-folder", "")
+		viper.Set("meta-folder-base", "")
+		// gameID 432 = Minecraft, classID 6 = mods.
+		got := getPathForFile(432, 6, 0, "sodium")
+		want := filepath.Join("mods", "sodium"+core.MetaExtension)
+
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("unknown class falls back to categoryID mapping", func(t *testing.T) {
+		viper.Set("meta-folder", "")
+		viper.Set("meta-folder-base", "")
+		// classID 999 is unknown, categoryID 5 = plugins.
+		got := getPathForFile(432, 999, 5, "luckperms")
+		want := filepath.Join("plugins", "luckperms"+core.MetaExtension)
+
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("unknown game falls back to flat layout", func(t *testing.T) {
+		viper.Set("meta-folder", "")
+		viper.Set("meta-folder-base", "")
+		got := getPathForFile(0, 0, 0, "sodium")
+		want := filepath.Join(".", "sodium"+core.MetaExtension)
+
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("explicit meta-folder wins over folder mapping", func(t *testing.T) {
+		viper.Set("meta-folder", "custom-folder")
+		viper.Set("meta-folder-base", "")
+		// classID 6 would normally map to "mods"; explicit setting overrides.
+		got := getPathForFile(432, 6, 0, "sodium")
+		want := filepath.Join("custom-folder", "sodium"+core.MetaExtension)
+
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("meta-folder-base is prepended", func(t *testing.T) {
+		viper.Set("meta-folder", "")
+		viper.Set("meta-folder-base", "packroot")
+		got := getPathForFile(432, 6, 0, "sodium")
+		want := filepath.Join("packroot", "mods", "sodium"+core.MetaExtension)
+
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}
+
+func TestGetSearchLoaderType(t *testing.T) {
+	cases := []struct {
+		name string
+		vers map[string]string
+		want modloaderType
+	}{
+		{"only fabric → Fabric", map[string]string{"fabric": "1"}, modloaderTypeFabric},
+		{"only forge → Forge", map[string]string{"forge": "1"}, modloaderTypeForge},
+		{"fabric + quilt → Any (multiple loaders)", map[string]string{"fabric": "1", "quilt": "1"}, modloaderTypeAny},
+		{"fabric + forge → Any (mixed)", map[string]string{"fabric": "1", "forge": "1"}, modloaderTypeAny},
+		{"only quilt → Any (no special case)", map[string]string{"quilt": "1"}, modloaderTypeAny},
+		{"only neoforge → Any (no special case)", map[string]string{"neoforge": "1"}, modloaderTypeAny},
+		{"empty → Any", map[string]string{}, modloaderTypeAny},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := core.Pack{Versions: tc.vers}
+
+			if got := getSearchLoaderType(p); got != tc.want {
+				t.Errorf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFilterLoaderTypeIndex(t *testing.T) {
+	cases := []struct {
+		name          string
+		packLoaders   []string
+		modLoaderType modloaderType
+		wantType      modloaderType
+		wantOK        bool
+	}{
+		{
+			name:          "empty packLoaders allows any file",
+			packLoaders:   nil,
+			modLoaderType: modloaderTypeForge,
+			wantType:      modloaderTypeAny,
+			wantOK:        true,
+		},
+		{
+			name:          "Any always passes through",
+			packLoaders:   []string{"fabric"},
+			modLoaderType: modloaderTypeAny,
+			wantType:      modloaderTypeAny,
+			wantOK:        true,
+		},
+		{
+			name:          "supported loader passes through with its type",
+			packLoaders:   []string{"fabric"},
+			modLoaderType: modloaderTypeFabric,
+			wantType:      modloaderTypeFabric,
+			wantOK:        true,
+		},
+		{
+			name:          "unsupported loader is filtered out",
+			packLoaders:   []string{"forge"},
+			modLoaderType: modloaderTypeFabric,
+			wantType:      modloaderTypeAny,
+			wantOK:        false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotType, gotOK := filterLoaderTypeIndex(tc.packLoaders, tc.modLoaderType)
+
+			if gotType != tc.wantType || gotOK != tc.wantOK {
+				t.Errorf("got (%d, %v), want (%d, %v)", gotType, gotOK, tc.wantType, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestFilterFileInfoLoaderIndex(t *testing.T) {
+	cases := []struct {
+		name        string
+		packLoaders []string
+		fileVers    []string
+		wantType    modloaderType
+		wantOK      bool
+	}{
+		{
+			name:        "empty packLoaders allows any file",
+			packLoaders: nil,
+			fileVers:    []string{"Fabric", "1.20.1"},
+			wantType:    modloaderTypeAny,
+			wantOK:      true,
+		},
+		{
+			name:        "file with matching loader returns that loader",
+			packLoaders: []string{"fabric"},
+			fileVers:    []string{"Fabric", "1.20.1"},
+			wantType:    modloaderTypeFabric,
+			wantOK:      true,
+		},
+		{
+			name:        "file with non-matching loader is rejected",
+			packLoaders: []string{"fabric"},
+			fileVers:    []string{"Forge", "1.20.1"},
+			wantType:    modloaderTypeAny,
+			wantOK:      false,
+		},
+		{
+			// Higher modloaderType index wins: Fabric (4) > Forge (1).
+			name:        "when multiple loaders match, higher index wins",
+			packLoaders: []string{"fabric", "forge"},
+			fileVers:    []string{"Fabric", "Forge", "1.20.1"},
+			wantType:    modloaderTypeFabric,
+			wantOK:      true,
+		},
+		{
+			// NeoForge (6) > Quilt (5) > Fabric (4).
+			name:        "neoforge beats quilt and fabric when all match",
+			packLoaders: []string{"fabric", "quilt", "neoforge"},
+			fileVers:    []string{"Fabric", "Quilt", "NeoForge", "1.20.1"},
+			wantType:    modloaderTypeNeoForge,
+			wantOK:      true,
+		},
+		{
+			name:        "no game versions of any kind means no match",
+			packLoaders: []string{"fabric"},
+			fileVers:    []string{"1.20.1"},
+			wantType:    modloaderTypeAny,
+			wantOK:      false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			info := modFileInfo{GameVersions: tc.fileVers}
+
+			gotType, gotOK := filterFileInfoLoaderIndex(tc.packLoaders, info)
+
+			if gotType != tc.wantType || gotOK != tc.wantOK {
+				t.Errorf("got (%d, %v), want (%d, %v)", gotType, gotOK, tc.wantType, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestMapDepOverride(t *testing.T) {
+	const (
+		fapiID  uint32 = 306612
+		qfapiID uint32 = 634179
+		flkID   uint32 = 308769
+		qklID   uint32 = 720410
+	)
+
+	cases := []struct {
+		name      string
+		depID     uint32
+		isQuilt   bool
+		mcVersion string
+		want      uint32
+	}{
+		{"FAPI under Quilt → QFAPI", fapiID, true, "1.20.1", qfapiID},
+		{"FAPI under Fabric is left alone", fapiID, false, "1.20.1", fapiID},
+		{"FLK under Quilt on 1.20.1 → QKL", flkID, true, "1.20.1", qklID},
+		{"FLK under Quilt on 1.19.0 is left alone (below 1.19.2)", flkID, true, "1.19.0", flkID},
+		{"FLK under Quilt on 1.18.2 is left alone (below 1.19.2)", flkID, true, "1.18.2", flkID},
+		{"unrelated dep ID is left alone", 12345, true, "1.20.1", 12345},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mapDepOverride(tc.depID, tc.isQuilt, tc.mcVersion); got != tc.want {
+				t.Errorf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseExportData(t *testing.T) {
+	t.Run("round-trip via ToMap → parseExportData", func(t *testing.T) {
+		original := cfExportData{ProjectID: 12345}
+
+		m, err := original.ToMap()
+		if err != nil {
+			t.Fatalf("ToMap: %v", err)
+		}
+
+		back, err := parseExportData(m)
+		if err != nil {
+			t.Fatalf("parseExportData: %v", err)
+		}
+
+		if back != original {
+			t.Errorf("round-trip mismatch: got %+v, want %+v", back, original)
+		}
+	})
+
+	t.Run("missing project-id yields zero value", func(t *testing.T) {
+		got, err := parseExportData(map[string]interface{}{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got.ProjectID != 0 {
+			t.Errorf("got %+v, want zero ProjectID", got)
+		}
+	})
+}
+
+func TestCfUpdateData_ToMap_RoundTrip(t *testing.T) {
+	original := cfUpdateData{
+		ProjectID: 306612,
+		FileID:    4567890,
+	}
+
+	m, err := original.ToMap()
+	if err != nil {
+		t.Fatalf("ToMap: %v", err)
+	}
+
+	// mapstructure tags map to "project-id" and "file-id".
+	if got := m["project-id"]; got != uint32(306612) {
+		t.Errorf("ToMap key project-id = %v (type %T), want 306612 uint32", got, got)
+	}
+
+	if got := m["file-id"]; got != uint32(4567890) {
+		t.Errorf("ToMap key file-id = %v (type %T), want 4567890 uint32", got, got)
+	}
+
+	parsed, err := cfUpdater{}.ParseUpdate(m)
+	if err != nil {
+		t.Fatalf("ParseUpdate: %v", err)
+	}
+
+	if parsed.(cfUpdateData) != original {
+		t.Errorf("round-trip mismatch:\n  got:  %+v\n  want: %+v", parsed, original)
+	}
+}
+
+func TestCfUpdater_ParseUpdate(t *testing.T) {
+	in := map[string]interface{}{
+		"project-id": uint32(306612),
+		"file-id":    uint32(4567890),
+	}
+
+	parsed, err := cfUpdater{}.ParseUpdate(in)
+	if err != nil {
+		t.Fatalf("ParseUpdate: %v", err)
+	}
+
+	data, ok := parsed.(cfUpdateData)
+	if !ok {
+		t.Fatalf("ParseUpdate returned %T, want cfUpdateData", parsed)
+	}
+
+	if data.ProjectID != 306612 || data.FileID != 4567890 {
+		t.Errorf("got %+v, want ProjectID=306612 FileID=4567890", data)
+	}
+}
+
+// cfFile builds a modFileInfo with the minimum fields findLatestFile
+// consumes (ID, FileName, GameVersions). Other fields default to
+// zero and are not exercised by the function.
+func cfFile(id uint32, fileName string, gameVersions []string) modFileInfo {
+	return modFileInfo{
+		ID:           id,
+		FileName:     fileName,
+		GameVersions: gameVersions,
+	}
+}
+
+func TestFindLatestFile_PicksHigherMCVersionIndex(t *testing.T) {
+	// mcVersions list semantics: later entries are preferred (the
+	// "main" MC version comes last). A file targeting the later
+	// entry should beat one targeting only the earlier entry.
+	info := modInfo{LatestFiles: []modFileInfo{
+		cfFile(1, "old.jar", []string{"Fabric", "1.19.4"}),
+		cfFile(2, "new.jar", []string{"Fabric", "1.20.1"}),
+	}}
+
+	id, _, name := findLatestFile(info, []string{"1.19.4", "1.20.1"}, []string{"fabric"})
+
+	if id != 2 || name != "new.jar" {
+		t.Errorf("got (id=%d, name=%q), want (2, new.jar)", id, name)
+	}
+}
+
+func TestFindLatestFile_HigherLoaderTypeWins(t *testing.T) {
+	// When both files target the same MC version, the higher
+	// modloaderType index wins (NeoForge=6 > Fabric=4 > Forge=1).
+	info := modInfo{LatestFiles: []modFileInfo{
+		cfFile(1, "fabric.jar", []string{"Fabric", "1.20.1"}),
+		cfFile(2, "neoforge.jar", []string{"NeoForge", "1.20.1"}),
+	}}
+
+	id, _, name := findLatestFile(info, []string{"1.20.1"}, []string{"fabric", "neoforge"})
+
+	if id != 2 || name != "neoforge.jar" {
+		t.Errorf("got (id=%d, name=%q), want (2, neoforge.jar)", id, name)
+	}
+}
+
+func TestFindLatestFile_HigherIDWinsAsTiebreaker(t *testing.T) {
+	// Same MC, same loader — higher file ID wins.
+	info := modInfo{LatestFiles: []modFileInfo{
+		cfFile(100, "first.jar", []string{"Fabric", "1.20.1"}),
+		cfFile(500, "second.jar", []string{"Fabric", "1.20.1"}),
+	}}
+
+	id, _, _ := findLatestFile(info, []string{"1.20.1"}, []string{"fabric"})
+
+	if id != 500 {
+		t.Errorf("got id=%d, want 500", id)
+	}
+}
+
+func TestFindLatestFile_SkipsFilesWithUnsupportedLoader(t *testing.T) {
+	// Forge-only file in a Fabric-only pack is filtered out by
+	// filterFileInfoLoaderIndex.
+	info := modInfo{LatestFiles: []modFileInfo{
+		cfFile(1, "forge.jar", []string{"Forge", "1.20.1"}),
+		cfFile(2, "fabric.jar", []string{"Fabric", "1.20.1"}),
+	}}
+
+	id, _, _ := findLatestFile(info, []string{"1.20.1"}, []string{"fabric"})
+
+	if id != 2 {
+		t.Errorf("got id=%d, want 2 (forge file should have been skipped)", id)
+	}
+}
+
+func TestFindLatestFile_SkipsFilesWithoutMatchingMCVersion(t *testing.T) {
+	info := modInfo{LatestFiles: []modFileInfo{
+		cfFile(1, "old-mc.jar", []string{"Fabric", "1.19.4"}),
+		cfFile(2, "current.jar", []string{"Fabric", "1.20.1"}),
+	}}
+
+	id, _, _ := findLatestFile(info, []string{"1.20.1"}, []string{"fabric"})
+
+	if id != 2 {
+		t.Errorf("got id=%d, want 2 (1.19.4-only file should have been skipped)", id)
+	}
+}
+
+func TestFindLatestFile_NoMatchReturnsZeroValues(t *testing.T) {
+	// All files filter out — neither MC version nor loader matches.
+	info := modInfo{LatestFiles: []modFileInfo{
+		cfFile(1, "forge.jar", []string{"Forge", "1.19.4"}),
+	}}
+
+	id, fileInfoData, name := findLatestFile(info, []string{"1.20.1"}, []string{"fabric"})
+
+	if id != 0 || fileInfoData != nil || name != "" {
+		t.Errorf("got (id=%d, fileInfo=%v, name=%q), want all zero", id, fileInfoData, name)
+	}
+}
+
+func TestFindLatestFile_GameVersionLatestFilesContribute(t *testing.T) {
+	// When LatestFiles is empty, the GameVersionLatestFiles loop is
+	// the only path to a match. fileInfoData stays nil for those
+	// entries (the index doesn't carry full modFileInfo).
+	info := modInfo{
+		GameVersionLatestFiles: []struct {
+			GameVersion string        `json:"gameVersion"`
+			ID          uint32        `json:"fileId"`
+			Name        string        `json:"filename"`
+			FileType    fileType      `json:"releaseType"`
+			Modloader   modloaderType `json:"modLoader"`
+		}{
+			{GameVersion: "1.20.1", ID: 42, Name: "via-index.jar", Modloader: modloaderTypeNeoForge},
+		},
+	}
+
+	id, fileInfoData, name := findLatestFile(info, []string{"1.20.1"}, []string{"neoforge"})
+
+	if id != 42 || name != "via-index.jar" {
+		t.Errorf("got (id=%d, name=%q), want (42, via-index.jar)", id, name)
+	}
+
+	if fileInfoData != nil {
+		t.Errorf("fileInfoData should be nil for GameVersionLatestFiles entries; got %+v", fileInfoData)
+	}
+}
+
+func TestCfUpdater_CheckUpdate(t *testing.T) {
+	pack := core.Pack{
+		Versions: map[string]string{
+			"minecraft": "1.20.1",
+			"fabric":    "0.15.0",
+		},
+	}
+
+	t.Run("mod without curseforge update data gets a per-mod error", func(t *testing.T) {
+		// Need at least one mod that DOES have CF data so the
+		// getModInfoMultiple call has something to return; otherwise
+		// the function call goes through cleanly with one mod
+		// erroring per-slot and the API mock not strictly required.
+		httpmock.Activate(t)
+		httpmock.RegisterResponder("POST",
+			"https://api.curseforge.com/v1/mods",
+			httpmock.NewStringResponder(200, `{"data":[]}`))
+
+		bad := &core.Mod{Name: "no-update", FileName: "bad.jar"}
+
+		results, err := cfUpdater{}.CheckUpdate([]*core.Mod{bad}, pack)
+		if err != nil {
+			t.Fatalf("CheckUpdate returned overall error: %v", err)
+		}
+
+		if results[0].Error == nil {
+			t.Errorf("expected per-mod error for missing update data, got %+v", results[0])
+		}
+	})
+
+	t.Run("same file ID yields UpdateAvailable=false", func(t *testing.T) {
+		httpmock.Activate(t)
+
+		// Server returns one modInfo for our requested project ID.
+		// The single latest-file entry has the SAME fileID the mod
+		// already has installed, so the function reports no update.
+		body := `{"data":[{
+			"id": 12345,
+			"name": "Test",
+			"latestFiles": [
+				{"id": 4567, "fileName": "test-1.0.0.jar", "gameVersions": ["Fabric", "1.20.1"]}
+			],
+			"latestFilesIndexes": []
+		}]}`
+
+		httpmock.RegisterResponder("POST",
+			"https://api.curseforge.com/v1/mods",
+			httpmock.NewStringResponder(200, body))
+
+		mod := newTestCurseforgeMod(t, "Test", "test-1.0.0.jar", 12345, 4567)
+
+		results, err := cfUpdater{}.CheckUpdate([]*core.Mod{mod}, pack)
+		if err != nil {
+			t.Fatalf("CheckUpdate: %v", err)
+		}
+
+		if results[0].Error != nil {
+			t.Fatalf("unexpected per-mod error: %v", results[0].Error)
+		}
+
+		if results[0].UpdateAvailable {
+			t.Errorf("expected UpdateAvailable=false (same fileID), got %+v", results[0])
+		}
+	})
+
+	t.Run("different file ID yields UpdateAvailable=true", func(t *testing.T) {
+		httpmock.Activate(t)
+
+		// Latest-file entry has fileID 9999, mod has 4567 installed.
+		body := `{"data":[{
+			"id": 12345,
+			"name": "Test",
+			"latestFiles": [
+				{"id": 9999, "fileName": "test-2.0.0.jar", "gameVersions": ["Fabric", "1.20.1"]}
+			],
+			"latestFilesIndexes": []
+		}]}`
+
+		httpmock.RegisterResponder("POST",
+			"https://api.curseforge.com/v1/mods",
+			httpmock.NewStringResponder(200, body))
+
+		mod := newTestCurseforgeMod(t, "Test", "test-1.0.0.jar", 12345, 4567)
+
+		results, err := cfUpdater{}.CheckUpdate([]*core.Mod{mod}, pack)
+		if err != nil {
+			t.Fatalf("CheckUpdate: %v", err)
+		}
+
+		if results[0].Error != nil {
+			t.Fatalf("unexpected per-mod error: %v", results[0].Error)
+		}
+
+		if !results[0].UpdateAvailable {
+			t.Fatalf("expected UpdateAvailable=true, got %+v", results[0])
+		}
+
+		want := "test-1.0.0.jar -> test-2.0.0.jar"
+		if results[0].UpdateString != want {
+			t.Errorf("UpdateString = %q, want %q", results[0].UpdateString, want)
+		}
+	})
+
+	t.Run("findLatestFile returns zero yields UpdateAvailable=false", func(t *testing.T) {
+		// Pack is fabric-only but the modInfo only carries a forge
+		// file. findLatestFile filters out unsupported loaders and
+		// returns 0 → the function reports no update available
+		// (rather than an error).
+		httpmock.Activate(t)
+
+		body := `{"data":[{
+			"id": 12345,
+			"name": "Test",
+			"latestFiles": [
+				{"id": 9999, "fileName": "forge-only.jar", "gameVersions": ["Forge", "1.20.1"]}
+			],
+			"latestFilesIndexes": []
+		}]}`
+
+		httpmock.RegisterResponder("POST",
+			"https://api.curseforge.com/v1/mods",
+			httpmock.NewStringResponder(200, body))
+
+		mod := newTestCurseforgeMod(t, "Test", "test-1.0.0.jar", 12345, 4567)
+
+		results, err := cfUpdater{}.CheckUpdate([]*core.Mod{mod}, pack)
+		if err != nil {
+			t.Fatalf("CheckUpdate: %v", err)
+		}
+
+		if results[0].UpdateAvailable {
+			t.Errorf("expected UpdateAvailable=false when no matching file exists, got %+v", results[0])
+		}
+	})
+
+	t.Run("getModInfoMultiple error surfaces as overall error", func(t *testing.T) {
+		// Unlike per-mod errors, a failure of the bulk modInfo API
+		// call bails out the whole function with an error return.
+		httpmock.Activate(t)
+
+		httpmock.RegisterResponder("POST",
+			"https://api.curseforge.com/v1/mods",
+			httpmock.NewStringResponder(500, `{"error":"boom"}`))
+
+		mod := newTestCurseforgeMod(t, "Test", "test.jar", 12345, 4567)
+
+		_, err := cfUpdater{}.CheckUpdate([]*core.Mod{mod}, pack)
+		if err == nil {
+			t.Error("expected overall error from 500 response, got nil")
+		}
+	})
+
+	t.Run("missing minecraft version surfaces as overall error", func(t *testing.T) {
+		// pack.GetSupportedMCVersions errors when "minecraft" is
+		// absent. The function returns that error before any HTTP
+		// is attempted.
+		t.Cleanup(func() { viper.Set("acceptable-game-versions", nil) })
+		viper.Set("acceptable-game-versions", nil)
+
+		emptyPack := core.Pack{Versions: map[string]string{}}
+
+		_, err := cfUpdater{}.CheckUpdate([]*core.Mod{{Name: "x"}}, emptyPack)
+		if err == nil {
+			t.Error("expected error when pack has no minecraft version, got nil")
+		}
+	})
+}

--- a/curseforge/detect_test.go
+++ b/curseforge/detect_test.go
@@ -1,0 +1,112 @@
+package curseforge
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestIsWhitespaceCharacter(t *testing.T) {
+	cases := []struct {
+		name string
+		b    byte
+		want bool
+	}{
+		{"tab (9)", 9, true},
+		{"line feed (10)", 10, true},
+		{"carriage return (13)", 13, true},
+		{"space (32)", 32, true},
+		{"vertical tab (11) is not in the set", 11, false},
+		{"form feed (12) is not in the set", 12, false},
+		{"NUL (0)", 0, false},
+		{"letter 'a'", 'a', false},
+		{"digit '0'", '0', false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isWhitespaceCharacter(tc.b); got != tc.want {
+				t.Errorf("isWhitespaceCharacter(%d) = %v, want %v", tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestComputeNormalizedArray(t *testing.T) {
+	cases := []struct {
+		name  string
+		input []byte
+		want  []byte
+	}{
+		{
+			name:  "input without whitespace passes through",
+			input: []byte("abcdef"),
+			want:  []byte("abcdef"),
+		},
+		{
+			name:  "spaces are stripped",
+			input: []byte("a b c"),
+			want:  []byte("abc"),
+		},
+		{
+			name:  "all four normalised whitespace characters are stripped",
+			input: []byte{'a', 9, 'b', 10, 'c', 13, 'd', 32, 'e'},
+			want:  []byte("abcde"),
+		},
+		{
+			name:  "vertical tab and form feed are preserved (not in the set)",
+			input: []byte{'a', 11, 'b', 12, 'c'},
+			want:  []byte{'a', 11, 'b', 12, 'c'},
+		},
+		{
+			name:  "empty input yields nil",
+			input: nil,
+			want:  nil,
+		},
+		{
+			name:  "all-whitespace input yields nil",
+			input: []byte{9, 10, 13, 32},
+			want:  nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeNormalizedArray(tc.input)
+
+			if !bytes.Equal(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetByteArrayHash(t *testing.T) {
+	// Regression pin: the murmur2 fingerprint of "abc" (no whitespace to
+	// strip) under seed 1. The exact value is whatever the upstream
+	// go-murmur library currently produces; pinning it catches changes
+	// in either go-murmur or our normalization pipeline.
+	const want uint32 = 1621425345
+	got := getByteArrayHash([]byte("abc"))
+
+	if got != want {
+		t.Errorf("getByteArrayHash([]byte(\"abc\")) = %d, want %d", got, want)
+	}
+}
+
+func TestGetByteArrayHash_NormalizesWhitespace(t *testing.T) {
+	// The function strips normalized whitespace before hashing, so
+	// these two inputs must produce identical fingerprints — the
+	// property that makes CurseForge fingerprint matching robust to
+	// line-ending differences between platforms.
+	a := getByteArrayHash([]byte("hello world"))
+	b := getByteArrayHash([]byte("hello\nworld"))
+	c := getByteArrayHash([]byte("hel l o\tw\rorld"))
+
+	if a == 0 {
+		t.Fatal("hash of non-empty input should not be 0")
+	}
+
+	if a != b || a != c {
+		t.Errorf("expected matching hashes after whitespace normalization, got %d / %d / %d", a, b, c)
+	}
+}

--- a/curseforge/murmur2/hash_test.go
+++ b/curseforge/murmur2/hash_test.go
@@ -1,0 +1,113 @@
+package murmur2
+
+import (
+	"hash"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	h := New()
+	if h == nil {
+		t.Fatal("New returned nil")
+	}
+
+	// Verify the result satisfies hash.Hash32 (it should at compile
+	// time, but a runtime check guards against future signature drift).
+	var _ hash.Hash32 = h
+}
+
+func TestMurmur2CF_SizeAndBlockSize(t *testing.T) {
+	m := &Murmur2CF{}
+
+	if got := m.Size(); got != 4 {
+		t.Errorf("Size() = %d, want 4", got)
+	}
+
+	if got := m.BlockSize(); got != 4 {
+		t.Errorf("BlockSize() = %d, want 4", got)
+	}
+}
+
+func TestMurmur2CF_RegressionPin(t *testing.T) {
+	// "abc" has no whitespace, so the normalized buffer equals the
+	// input. Murmur2 seed=1 over those three bytes produces the pinned
+	// fingerprint — same value used by detect.go's getByteArrayHash
+	// test (which calls into this implementation).
+	m := &Murmur2CF{}
+	if _, err := m.Write([]byte("abc")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if got := m.Sum32(); got != 1621425345 {
+		t.Errorf("Sum32 for \"abc\" = %d, want 1621425345", got)
+	}
+}
+
+func TestMurmur2CF_StripsWhitespace(t *testing.T) {
+	// The CF variant of Murmur2 ignores tab/LF/CR/space before
+	// hashing, so these three inputs must produce identical
+	// fingerprints. This is the property CurseForge fingerprint
+	// matching relies on for cross-platform stability.
+	makeHash := func(input string) uint32 {
+		m := &Murmur2CF{}
+		_, _ = m.Write([]byte(input))
+		return m.Sum32()
+	}
+
+	a := makeHash("hello world")
+	b := makeHash("hello\nworld")
+	c := makeHash("hel l o\tw\rorld")
+
+	if a == 0 {
+		t.Fatal("hash of non-empty content should not be 0")
+	}
+
+	if a != b || a != c {
+		t.Errorf("expected identical hashes after whitespace normalization; got %d / %d / %d", a, b, c)
+	}
+}
+
+func TestMurmur2CF_Reset(t *testing.T) {
+	m := &Murmur2CF{}
+	_, _ = m.Write([]byte("hello"))
+	before := m.Sum32()
+
+	m.Reset()
+	after := m.Sum32()
+
+	if before == after {
+		t.Errorf("Sum32 returned same value (%d) before and after Reset; expected different", before)
+	}
+
+	// After Reset the buffer is empty; the hash should match the
+	// fresh-instance "empty input" hash.
+	m2 := &Murmur2CF{}
+	if m2.Sum32() != after {
+		t.Errorf("post-Reset hash %d differs from fresh-instance empty-input hash %d", after, m2.Sum32())
+	}
+}
+
+func TestMurmur2CF_WriteReturnsFullLength(t *testing.T) {
+	// Even when bytes are stripped from the internal buffer, Write
+	// must report having consumed every byte handed to it — that's
+	// what the io.Writer contract requires.
+	m := &Murmur2CF{}
+	input := []byte("  hello\nworld  ")
+
+	n, err := m.Write(input)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if n != len(input) {
+		t.Errorf("Write returned n = %d, want %d (must report all bytes consumed even when some are stripped)",
+			n, len(input))
+	}
+}
+
+// Note: Murmur2CF.Sum(b) shares the LengthHasher.Sum bug — when b is
+// non-nil and has cap < 4, it allocates and overwrites; otherwise it
+// stomps the supplied prefix at offset 0 instead of appending. All
+// current callers pass nil so the bug is latent. The tests above use
+// Sum32 (which always calls Sum(nil)) to sidestep the issue. See the
+// LengthHasher entry in .claude/TODO.md for the shared fix.

--- a/curseforge/packinterop/manifest_test.go
+++ b/curseforge/packinterop/manifest_test.go
@@ -1,0 +1,114 @@
+package packinterop
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCursePackMeta_Accessors(t *testing.T) {
+	m := cursePackMeta{
+		NameInternal: "Test Pack",
+		Version:      "1.0.0",
+		Author:       "tester",
+	}
+
+	if got := m.Name(); got != "Test Pack" {
+		t.Errorf("Name = %q, want %q", got, "Test Pack")
+	}
+
+	if got := m.PackVersion(); got != "1.0.0" {
+		t.Errorf("PackVersion = %q, want %q", got, "1.0.0")
+	}
+
+	if got := m.PackAuthor(); got != "tester" {
+		t.Errorf("PackAuthor = %q, want %q", got, "tester")
+	}
+}
+
+func TestCursePackMeta_Versions(t *testing.T) {
+	t.Run("parses minecraft and modloader IDs", func(t *testing.T) {
+		m := cursePackMeta{}
+		m.Minecraft.Version = "1.20.1"
+		m.Minecraft.ModLoaders = []modLoaderDef{
+			{ID: "fabric-0.15.0", Primary: true},
+		}
+
+		got := m.Versions()
+		want := map[string]string{
+			"minecraft": "1.20.1",
+			"fabric":    "0.15.0",
+		}
+
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("strips minecraft-version prefix from forge", func(t *testing.T) {
+		// Forge versions in this manifest format are emitted as
+		// "<mcVersion>-<forgeVersion>"; Versions() peels the prefix
+		// so callers get the bare forge version.
+		m := cursePackMeta{}
+		m.Minecraft.Version = "1.20.1"
+		m.Minecraft.ModLoaders = []modLoaderDef{
+			{ID: "forge-1.20.1-47.1.0", Primary: true},
+		}
+
+		got := m.Versions()
+		if got["forge"] != "47.1.0" {
+			t.Errorf("forge = %q, want %q", got["forge"], "47.1.0")
+		}
+	})
+
+	t.Run("modloader ID without a dash is silently dropped", func(t *testing.T) {
+		// ID values without a "-" don't match SplitN(..., 2) → len 2,
+		// so they're skipped. Pinning current behavior.
+		m := cursePackMeta{}
+		m.Minecraft.Version = "1.20.1"
+		m.Minecraft.ModLoaders = []modLoaderDef{
+			{ID: "fabric", Primary: true},
+		}
+
+		got := m.Versions()
+		if _, ok := got["fabric"]; ok {
+			t.Errorf("expected fabric to be absent from versions; got %v", got)
+		}
+	})
+}
+
+func TestCursePackMeta_Mods(t *testing.T) {
+	m := cursePackMeta{
+		Files: []struct {
+			ProjectID uint32 `json:"projectID"`
+			FileID    uint32 `json:"fileID"`
+			Required  bool   `json:"required"`
+		}{
+			{ProjectID: 1, FileID: 10, Required: true},
+			{ProjectID: 2, FileID: 20, Required: false},
+		},
+	}
+
+	got := m.Mods()
+
+	if len(got) != 2 {
+		t.Fatalf("got %d mods, want 2", len(got))
+	}
+
+	// Required:true → OptionalDisabled:false (logical inversion).
+	if got[0].ProjectID != 1 || got[0].FileID != 10 || got[0].OptionalDisabled {
+		t.Errorf("got[0] = %+v, want ProjectID=1 FileID=10 OptionalDisabled=false", got[0])
+	}
+
+	if got[1].ProjectID != 2 || got[1].FileID != 20 || !got[1].OptionalDisabled {
+		t.Errorf("got[1] = %+v, want ProjectID=2 FileID=20 OptionalDisabled=true", got[1])
+	}
+}
+
+func TestCursePackOverrideWrapper_Name(t *testing.T) {
+	// The wrapper exists solely to override the Name() method while
+	// delegating Open() to the wrapped file. Verify the rename works.
+	w := cursePackOverrideWrapper{name: "renamed.txt"}
+	if got := w.Name(); got != "renamed.txt" {
+		t.Errorf("Name = %q, want %q", got, "renamed.txt")
+	}
+}

--- a/curseforge/packinterop/minecraftinstance_test.go
+++ b/curseforge/packinterop/minecraftinstance_test.go
@@ -1,0 +1,114 @@
+package packinterop
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTwitchInstalledPackMeta_Accessors(t *testing.T) {
+	// PackAuthor and PackVersion are intentionally empty for the
+	// Twitch (Overwolf) launcher's installed-pack format — that
+	// metadata isn't part of the installed-pack JSON. Pinning that.
+	m := twitchInstalledPackMeta{NameInternal: "Installed Pack"}
+
+	if got := m.Name(); got != "Installed Pack" {
+		t.Errorf("Name = %q, want %q", got, "Installed Pack")
+	}
+
+	if got := m.PackAuthor(); got != "" {
+		t.Errorf("PackAuthor = %q, want \"\"", got)
+	}
+
+	if got := m.PackVersion(); got != "" {
+		t.Errorf("PackVersion = %q, want \"\"", got)
+	}
+}
+
+func TestTwitchInstalledPackMeta_Versions_Forge(t *testing.T) {
+	t.Run("MavenVersionString form", func(t *testing.T) {
+		m := twitchInstalledPackMeta{MCVersion: "1.20.1"}
+		m.Modloader.Name = "forge-something"
+		m.Modloader.MavenVersionString = "net.minecraftforge:forge:1.20.1-47.1.0"
+
+		got := m.Versions()
+		want := map[string]string{
+			"minecraft": "1.20.1",
+			"forge":     "47.1.0",
+		}
+
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("falls back to Modloader.Name when MavenVersionString is empty", func(t *testing.T) {
+		m := twitchInstalledPackMeta{MCVersion: "1.20.1"}
+		m.Modloader.Name = "forge-1.20.1-47.1.0"
+
+		got := m.Versions()
+		if got["forge"] != "47.1.0" {
+			t.Errorf("forge = %q, want %q", got["forge"], "47.1.0")
+		}
+	})
+}
+
+func TestTwitchInstalledPackMeta_Versions_Fabric(t *testing.T) {
+	t.Run("MavenVersionString form", func(t *testing.T) {
+		m := twitchInstalledPackMeta{MCVersion: "1.20.1"}
+		m.Modloader.Name = "fabric-something"
+		m.Modloader.MavenVersionString = "net.fabricmc:fabric-loader:0.15.0"
+
+		got := m.Versions()
+		if got["fabric"] != "0.15.0" {
+			t.Errorf("fabric = %q, want %q", got["fabric"], "0.15.0")
+		}
+	})
+
+	t.Run("falls back to Modloader.Name when MavenVersionString is empty", func(t *testing.T) {
+		m := twitchInstalledPackMeta{MCVersion: "1.20.1"}
+		m.Modloader.Name = "fabric-0.15.0"
+
+		got := m.Versions()
+		if got["fabric"] != "0.15.0" {
+			t.Errorf("fabric = %q, want %q", got["fabric"], "0.15.0")
+		}
+	})
+}
+
+func TestTwitchInstalledPackMeta_Mods(t *testing.T) {
+	m := twitchInstalledPackMeta{}
+	m.ModsInternal = []struct {
+		ID   uint32 `json:"addonID"`
+		File struct {
+			ID             uint32 `json:"id"`
+			FileNameOnDisk string
+		} `json:"installedFile"`
+	}{
+		{ID: 1},
+		{ID: 2},
+	}
+	// .disabled suffix triggers OptionalDisabled = true.
+	m.ModsInternal[0].File.ID = 10
+	m.ModsInternal[0].File.FileNameOnDisk = "mod-a.jar"
+	m.ModsInternal[1].File.ID = 20
+	m.ModsInternal[1].File.FileNameOnDisk = "mod-b.jar.disabled"
+
+	got := m.Mods()
+
+	if len(got) != 2 {
+		t.Fatalf("got %d mods, want 2", len(got))
+	}
+
+	if got[0].OptionalDisabled {
+		t.Errorf("mod-a.jar should NOT be marked OptionalDisabled; got %+v", got[0])
+	}
+
+	if !got[1].OptionalDisabled {
+		t.Errorf("mod-b.jar.disabled SHOULD be marked OptionalDisabled; got %+v", got[1])
+	}
+
+	// Verify ID and FileID flow through.
+	if got[0].ProjectID != 1 || got[0].FileID != 10 {
+		t.Errorf("got[0] = %+v, want ProjectID=1 FileID=10", got[0])
+	}
+}

--- a/curseforge/packinterop/translation_test.go
+++ b/curseforge/packinterop/translation_test.go
@@ -1,0 +1,158 @@
+package packinterop
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/packwiz/packwiz/core"
+)
+
+func TestWriteManifestFromPack_RoundTrip(t *testing.T) {
+	// Write a pack out to a manifest, parse it back into
+	// cursePackMeta, and verify all the round-tripped fields.
+	pack := core.Pack{
+		Name:    "TestPack",
+		Version: "1.0.0",
+		Author:  "tester",
+		Versions: map[string]string{
+			"minecraft": "1.20.1",
+			"fabric":    "0.15.0",
+		},
+	}
+
+	refs := []AddonFileReference{
+		{ProjectID: 100, FileID: 1000, OptionalDisabled: false},
+		{ProjectID: 200, FileID: 2000, OptionalDisabled: true},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteManifestFromPack(pack, refs, 42, &buf); err != nil {
+		t.Fatalf("WriteManifestFromPack: %v", err)
+	}
+
+	// Parse the manifest back. We use a local struct mirror to read
+	// the on-disk shape directly instead of round-tripping through
+	// cursePackMeta (which unexports importSrc and has json-tagged
+	// nested struct fields that don't deserialize cleanly without
+	// the unexported importSrc dependency).
+	var m cursePackMeta
+	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if m.NameInternal != "TestPack" {
+		t.Errorf("name = %q, want TestPack", m.NameInternal)
+	}
+
+	if m.Version != "1.0.0" {
+		t.Errorf("version = %q, want 1.0.0", m.Version)
+	}
+
+	if m.Author != "tester" {
+		t.Errorf("author = %q, want tester", m.Author)
+	}
+
+	if m.ProjectID != 42 {
+		t.Errorf("projectID = %d, want 42", m.ProjectID)
+	}
+
+	if m.ManifestType != "minecraftModpack" {
+		t.Errorf("manifestType = %q, want minecraftModpack", m.ManifestType)
+	}
+
+	if m.Overrides != "overrides" {
+		t.Errorf("overrides = %q, want overrides", m.Overrides)
+	}
+
+	if m.Minecraft.Version != "1.20.1" {
+		t.Errorf("minecraft.version = %q, want 1.20.1", m.Minecraft.Version)
+	}
+
+	if len(m.Minecraft.ModLoaders) != 1 {
+		t.Fatalf("modloader count = %d, want 1", len(m.Minecraft.ModLoaders))
+	}
+
+	if m.Minecraft.ModLoaders[0].ID != "fabric-0.15.0" {
+		t.Errorf("modloader[0].ID = %q, want fabric-0.15.0", m.Minecraft.ModLoaders[0].ID)
+	}
+
+	if !m.Minecraft.ModLoaders[0].Primary {
+		t.Error("modloader[0].Primary = false, want true")
+	}
+
+	if len(m.Files) != 2 {
+		t.Fatalf("files count = %d, want 2", len(m.Files))
+	}
+
+	// OptionalDisabled is inverted into Required on write.
+	if m.Files[0].ProjectID != 100 || m.Files[0].FileID != 1000 || !m.Files[0].Required {
+		t.Errorf("file[0] = %+v, want ProjectID=100 FileID=1000 Required=true", m.Files[0])
+	}
+
+	if m.Files[1].ProjectID != 200 || m.Files[1].FileID != 2000 || m.Files[1].Required {
+		t.Errorf("file[1] = %+v, want ProjectID=200 FileID=2000 Required=false", m.Files[1])
+	}
+}
+
+func TestWriteManifestFromPack_LoaderPriority(t *testing.T) {
+	// When multiple loaders are present in pack.Versions, the function
+	// picks the first match in priority order: fabric → forge →
+	// neoforge → quilt. The if/else-if chain stops at the first match,
+	// so fabric beats everything else when both are set.
+	cases := []struct {
+		name     string
+		versions map[string]string
+		wantID   string
+	}{
+		{
+			name:     "fabric only",
+			versions: map[string]string{"minecraft": "1.20.1", "fabric": "0.15.0"},
+			wantID:   "fabric-0.15.0",
+		},
+		{
+			name:     "forge only",
+			versions: map[string]string{"minecraft": "1.20.1", "forge": "47.1.0"},
+			wantID:   "forge-47.1.0",
+		},
+		{
+			name:     "neoforge only",
+			versions: map[string]string{"minecraft": "1.20.1", "neoforge": "20.4.230"},
+			wantID:   "neoforge-20.4.230",
+		},
+		{
+			name:     "quilt only",
+			versions: map[string]string{"minecraft": "1.20.1", "quilt": "0.21.0"},
+			wantID:   "quilt-0.21.0",
+		},
+		{
+			// fabric+forge → fabric wins per the if-chain order.
+			name:     "fabric beats forge when both present",
+			versions: map[string]string{"minecraft": "1.20.1", "fabric": "0.15.0", "forge": "47.1.0"},
+			wantID:   "fabric-0.15.0",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := WriteManifestFromPack(core.Pack{Versions: tc.versions}, nil, 0, &buf)
+			if err != nil {
+				t.Fatalf("WriteManifestFromPack: %v", err)
+			}
+
+			var m cursePackMeta
+			if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+
+			if len(m.Minecraft.ModLoaders) != 1 {
+				t.Fatalf("expected 1 modloader, got %d", len(m.Minecraft.ModLoaders))
+			}
+
+			if m.Minecraft.ModLoaders[0].ID != tc.wantID {
+				t.Errorf("modloader ID = %q, want %q", m.Minecraft.ModLoaders[0].ID, tc.wantID)
+			}
+		})
+	}
+}

--- a/curseforge/request_test.go
+++ b/curseforge/request_test.go
@@ -1,0 +1,435 @@
+package curseforge
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+)
+
+func TestDecodeDefaultKey(t *testing.T) {
+	// The default API key is a hardcoded base64 string at the top of
+	// request.go. decodeDefaultKey should produce a non-empty result;
+	// failure would panic (caught by the test runner).
+	got := decodeDefaultKey()
+
+	if got == "" {
+		t.Fatal("decodeDefaultKey returned empty string")
+	}
+
+	// The decoded value should not still look like base64 — sanity
+	// check that decoding actually happened.
+	if got == cfApiKeyDefault {
+		t.Errorf("decoded value equals the base64 input, decoding likely failed")
+	}
+}
+
+func TestModFileInfoGetBestHash(t *testing.T) {
+	mkHash := func(algo hashAlgo, value string) struct {
+		Value     string   `json:"value"`
+		Algorithm hashAlgo `json:"algo"`
+	} {
+		return struct {
+			Value     string   `json:"value"`
+			Algorithm hashAlgo `json:"algo"`
+		}{Value: value, Algorithm: algo}
+	}
+
+	type hashEntry = struct {
+		Value     string   `json:"value"`
+		Algorithm hashAlgo `json:"algo"`
+	}
+
+	t.Run("falls back to murmur2 of Fingerprint when Hashes is nil", func(t *testing.T) {
+		f := modFileInfo{Fingerprint: 4242}
+
+		hash, format := f.getBestHash()
+
+		if hash != "4242" || format != "murmur2" {
+			t.Errorf("got (%q, %q), want (4242, murmur2)", hash, format)
+		}
+	})
+
+	t.Run("falls back to murmur2 when Hashes is empty", func(t *testing.T) {
+		f := modFileInfo{Fingerprint: 7, Hashes: []hashEntry{}}
+
+		hash, format := f.getBestHash()
+
+		if hash != "7" || format != "murmur2" {
+			t.Errorf("got (%q, %q), want (7, murmur2)", hash, format)
+		}
+	})
+
+	t.Run("md5 wins over murmur2", func(t *testing.T) {
+		f := modFileInfo{
+			Fingerprint: 4242,
+			Hashes:      []hashEntry{mkHash(hashAlgoMD5, "md5-value")},
+		}
+
+		hash, format := f.getBestHash()
+
+		if hash != "md5-value" || format != "md5" {
+			t.Errorf("got (%q, %q), want (md5-value, md5)", hash, format)
+		}
+	})
+
+	t.Run("sha1 wins over md5 and murmur2", func(t *testing.T) {
+		f := modFileInfo{
+			Fingerprint: 4242,
+			Hashes: []hashEntry{
+				mkHash(hashAlgoMD5, "md5-value"),
+				mkHash(hashAlgoSHA1, "sha1-value"),
+			},
+		}
+
+		hash, format := f.getBestHash()
+
+		if hash != "sha1-value" || format != "sha1" {
+			t.Errorf("got (%q, %q), want (sha1-value, sha1)", hash, format)
+		}
+	})
+
+	t.Run("sha1 wins regardless of array order", func(t *testing.T) {
+		f := modFileInfo{
+			Hashes: []hashEntry{
+				mkHash(hashAlgoSHA1, "sha1-value"),
+				mkHash(hashAlgoMD5, "md5-value"),
+			},
+		}
+
+		hash, format := f.getBestHash()
+
+		if hash != "sha1-value" || format != "sha1" {
+			t.Errorf("got (%q, %q), want (sha1-value, sha1)", hash, format)
+		}
+	})
+}
+
+func TestGetModInfo(t *testing.T) {
+	t.Run("happy path returns the deserialized mod", func(t *testing.T) {
+		httpmock.Activate(t)
+
+		body := `{"data":{
+			"id": 12345,
+			"name": "Test Mod",
+			"slug": "test-mod",
+			"summary": "A mod used by TestGetModInfo",
+			"gameId": 432,
+			"classId": 6,
+			"latestFiles": [
+				{"id": 4567, "fileName": "test-mod-1.0.0.jar", "gameVersions": ["Fabric","1.20.1"]}
+			],
+			"latestFilesIndexes": [],
+			"modLoaders": ["Fabric"],
+			"links": {"websiteUrl": "https://www.curseforge.com/minecraft/mc-mods/test-mod"}
+		}}`
+
+		httpmock.RegisterResponder("GET", "https://api.curseforge.com/v1/mods/12345",
+			httpmock.NewStringResponder(200, body))
+
+		info, err := cfDefaultClient.getModInfo(12345)
+		if err != nil {
+			t.Fatalf("getModInfo: %v", err)
+		}
+
+		if info.ID != 12345 {
+			t.Errorf("ID = %d, want 12345", info.ID)
+		}
+
+		if info.Name != "Test Mod" {
+			t.Errorf("Name = %q, want %q", info.Name, "Test Mod")
+		}
+
+		if len(info.LatestFiles) != 1 || info.LatestFiles[0].ID != 4567 {
+			t.Errorf("LatestFiles = %+v, want one entry with ID 4567", info.LatestFiles)
+		}
+	})
+
+	t.Run("rejects response with mismatched ID", func(t *testing.T) {
+		httpmock.Activate(t)
+
+		// Server responds with a different ID than what was requested.
+		body := `{"data":{"id": 999, "name": "Wrong"}}`
+		httpmock.RegisterResponder("GET", "https://api.curseforge.com/v1/mods/12345",
+			httpmock.NewStringResponder(200, body))
+
+		_, err := cfDefaultClient.getModInfo(12345)
+		if err == nil {
+			t.Error("expected error for ID mismatch, got nil")
+		}
+	})
+
+	t.Run("propagates non-200 status as error", func(t *testing.T) {
+		httpmock.Activate(t)
+
+		httpmock.RegisterResponder("GET", "https://api.curseforge.com/v1/mods/12345",
+			httpmock.NewStringResponder(500, `{"error":"boom"}`))
+
+		_, err := cfDefaultClient.getModInfo(12345)
+		if err == nil {
+			t.Error("expected error for 500 response, got nil")
+		}
+	})
+}
+
+func TestGetFileInfo(t *testing.T) {
+	t.Run("happy path returns the deserialized file", func(t *testing.T) {
+		httpmock.Activate(t)
+
+		body := `{"data":{
+			"id": 4567,
+			"modId": 12345,
+			"fileName": "test-mod-1.0.0.jar",
+			"displayName": "Test Mod 1.0.0",
+			"fileLength": 1024,
+			"downloadUrl": "https://edge.forgecdn.net/files/4/5/test-mod.jar",
+			"gameVersions": ["Fabric","1.20.1"],
+			"fileFingerprint": 42424242,
+			"hashes": [{"value":"sha1value","algo":1},{"value":"md5value","algo":2}]
+		}}`
+
+		httpmock.RegisterResponder("GET", "https://api.curseforge.com/v1/mods/12345/files/4567",
+			httpmock.NewStringResponder(200, body))
+
+		info, err := cfDefaultClient.getFileInfo(12345, 4567)
+		if err != nil {
+			t.Fatalf("getFileInfo: %v", err)
+		}
+
+		if info.ID != 4567 {
+			t.Errorf("ID = %d, want 4567", info.ID)
+		}
+
+		if info.ModID != 12345 {
+			t.Errorf("ModID = %d, want 12345", info.ModID)
+		}
+
+		if info.FileName != "test-mod-1.0.0.jar" {
+			t.Errorf("FileName = %q, want %q", info.FileName, "test-mod-1.0.0.jar")
+		}
+
+		if info.Fingerprint != 42424242 {
+			t.Errorf("Fingerprint = %d, want 42424242", info.Fingerprint)
+		}
+
+		// Verify the hash slice deserialized with both algorithm enum
+		// values intact.
+		if len(info.Hashes) != 2 {
+			t.Fatalf("Hashes count = %d, want 2", len(info.Hashes))
+		}
+	})
+
+	t.Run("rejects response with mismatched file ID", func(t *testing.T) {
+		httpmock.Activate(t)
+
+		body := `{"data":{"id": 999, "modId": 12345}}`
+		httpmock.RegisterResponder("GET", "https://api.curseforge.com/v1/mods/12345/files/4567",
+			httpmock.NewStringResponder(200, body))
+
+		_, err := cfDefaultClient.getFileInfo(12345, 4567)
+		if err == nil {
+			t.Error("expected error for file ID mismatch, got nil")
+		}
+	})
+}
+
+func TestGetModInfoMultiple(t *testing.T) {
+	httpmock.Activate(t)
+
+	body := `{"data":[
+		{"id": 1, "name": "A"},
+		{"id": 2, "name": "B"},
+		{"id": 3, "name": "C"}
+	]}`
+
+	httpmock.RegisterResponder("POST", "https://api.curseforge.com/v1/mods",
+		httpmock.NewStringResponder(200, body))
+
+	infos, err := cfDefaultClient.getModInfoMultiple([]uint32{1, 2, 3})
+	if err != nil {
+		t.Fatalf("getModInfoMultiple: %v", err)
+	}
+
+	if len(infos) != 3 {
+		t.Fatalf("got %d infos, want 3", len(infos))
+	}
+
+	wantNames := []string{"A", "B", "C"}
+	for i, info := range infos {
+		if info.Name != wantNames[i] {
+			t.Errorf("infos[%d].Name = %q, want %q", i, info.Name, wantNames[i])
+		}
+	}
+}
+
+func TestGetFileInfoMultiple(t *testing.T) {
+	httpmock.Activate(t)
+
+	body := `{"data":[
+		{"id": 100, "modId": 1, "fileName": "a.jar"},
+		{"id": 200, "modId": 2, "fileName": "b.jar"}
+	]}`
+
+	httpmock.RegisterResponder("POST", "https://api.curseforge.com/v1/mods/files",
+		httpmock.NewStringResponder(200, body))
+
+	infos, err := cfDefaultClient.getFileInfoMultiple([]uint32{100, 200})
+	if err != nil {
+		t.Fatalf("getFileInfoMultiple: %v", err)
+	}
+
+	if len(infos) != 2 {
+		t.Fatalf("got %d infos, want 2", len(infos))
+	}
+
+	if infos[0].FileName != "a.jar" || infos[1].FileName != "b.jar" {
+		t.Errorf("got filenames %q / %q, want a.jar / b.jar",
+			infos[0].FileName, infos[1].FileName)
+	}
+}
+
+func TestGetSearch(t *testing.T) {
+	httpmock.Activate(t)
+
+	body := `{"data":[
+		{"id": 1, "name": "Test Mod 1", "slug": "test-mod-1"},
+		{"id": 2, "name": "Test Mod 2", "slug": "test-mod-2"}
+	]}`
+
+	// The query string varies (pageSize / gameId / slug / etc. can
+	// appear in any order); match the path prefix.
+	httpmock.RegisterRegexpResponder("GET",
+		regexp.MustCompile(`^https://api\.curseforge\.com/v1/mods/search\?`),
+		httpmock.NewStringResponder(200, body))
+
+	results, err := cfDefaultClient.getSearch("test", "", 432, 6, 0, "1.20.1", modloaderTypeFabric)
+	if err != nil {
+		t.Fatalf("getSearch: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+
+	if results[0].Slug != "test-mod-1" || results[1].Slug != "test-mod-2" {
+		t.Errorf("got slugs %q / %q, want test-mod-1 / test-mod-2",
+			results[0].Slug, results[1].Slug)
+	}
+}
+
+func TestGetGames(t *testing.T) {
+	httpmock.Activate(t)
+
+	// The gameStatus and gameApiStatus enums are encoded as uints,
+	// so we use numeric literals — gameStatusLive = 6, gameApiStatusPublic = 2.
+	body := `{"data":[
+		{"id": 432, "name": "Minecraft", "slug": "minecraft", "status": 6, "apiStatus": 2}
+	]}`
+
+	httpmock.RegisterResponder("GET",
+		"https://api.curseforge.com/v1/games",
+		httpmock.NewStringResponder(200, body))
+
+	games, err := cfDefaultClient.getGames()
+	if err != nil {
+		t.Fatalf("getGames: %v", err)
+	}
+
+	if len(games) != 1 {
+		t.Fatalf("got %d games, want 1", len(games))
+	}
+
+	g := games[0]
+	if g.ID != 432 || g.Slug != "minecraft" {
+		t.Errorf("game = %+v, want ID 432 / slug minecraft", g)
+	}
+
+	if g.Status != gameStatusLive {
+		t.Errorf("Status = %d, want gameStatusLive (%d)", g.Status, gameStatusLive)
+	}
+
+	if g.APIStatus != gameApiStatusPublic {
+		t.Errorf("APIStatus = %d, want gameApiStatusPublic (%d)", g.APIStatus, gameApiStatusPublic)
+	}
+}
+
+func TestGetCategories(t *testing.T) {
+	httpmock.Activate(t)
+
+	body := `{"data":[
+		{"id": 6, "slug": "mc-mods", "isClass": true, "classId": 0},
+		{"id": 12, "slug": "resource-packs", "isClass": true, "classId": 0},
+		{"id": 423, "slug": "magic", "isClass": false, "classId": 6}
+	]}`
+
+	httpmock.RegisterResponder("GET",
+		"https://api.curseforge.com/v1/categories?gameId=432",
+		httpmock.NewStringResponder(200, body))
+
+	cats, err := cfDefaultClient.getCategories(432)
+	if err != nil {
+		t.Fatalf("getCategories: %v", err)
+	}
+
+	if len(cats) != 3 {
+		t.Fatalf("got %d categories, want 3", len(cats))
+	}
+
+	// Verify the class / non-class distinction round-trips.
+	if !cats[0].IsClass || cats[0].ClassID != 0 {
+		t.Errorf("first entry should be a class with classId=0; got %+v", cats[0])
+	}
+
+	if cats[2].IsClass || cats[2].ClassID != 6 {
+		t.Errorf("last entry should be a non-class under classId=6; got %+v", cats[2])
+	}
+}
+
+func TestGetFingerprintInfo(t *testing.T) {
+	httpmock.Activate(t)
+
+	// Body covers the three branches detect.go cares about: an exact
+	// match (with the embedded file and a latestFiles slice), an
+	// exact-fingerprints index, and a list of unmatched fingerprints.
+	body := `{"data":{
+		"isCacheBuilt": true,
+		"exactMatches": [
+			{
+				"id": 12345,
+				"file": {"id": 4567, "modId": 12345, "fileName": "matched.jar", "fileFingerprint": 1111111111},
+				"latestFiles": []
+			}
+		],
+		"exactFingerprints": [1111111111],
+		"partialMatches": [],
+		"partialMatchFingerprints": {},
+		"installedFingerprints": [1111111111, 2222222222],
+		"unmatchedFingerprints": [2222222222]
+	}}`
+
+	httpmock.RegisterResponder("POST",
+		"https://api.curseforge.com/v1/fingerprints",
+		httpmock.NewStringResponder(200, body))
+
+	resp, err := cfDefaultClient.getFingerprintInfo([]uint32{1111111111, 2222222222})
+	if err != nil {
+		t.Fatalf("getFingerprintInfo: %v", err)
+	}
+
+	if !resp.IsCacheBuilt {
+		t.Error("IsCacheBuilt = false, want true")
+	}
+
+	if len(resp.ExactMatches) != 1 {
+		t.Fatalf("ExactMatches count = %d, want 1", len(resp.ExactMatches))
+	}
+
+	match := resp.ExactMatches[0]
+	if match.ID != 12345 || match.File.ID != 4567 || match.File.FileName != "matched.jar" {
+		t.Errorf("unexpected exact match: %+v", match)
+	}
+
+	if len(resp.UnmatchedFingerprints) != 1 || resp.UnmatchedFingerprints[0] != 2222222222 {
+		t.Errorf("UnmatchedFingerprints = %v, want [2222222222]", resp.UnmatchedFingerprints)
+	}
+}

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -1,0 +1,116 @@
+package github
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"reflect"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/mitchellh/mapstructure"
+)
+
+func TestFetchRepo(t *testing.T) {
+	t.Run("happy path returns the deserialized repo", func(t *testing.T) {
+		httpmock.Activate(t)
+
+		body := `{
+			"id": 12345,
+			"name": "packwiz",
+			"full_name": "packwiz/packwiz"
+		}`
+
+		httpmock.RegisterResponder("GET",
+			"https://api.github.com/repos/packwiz/packwiz",
+			httpmock.NewStringResponder(200, body))
+
+		repo, err := fetchRepo("packwiz/packwiz")
+		if err != nil {
+			t.Fatalf("fetchRepo: %v", err)
+		}
+
+		if repo.ID != 12345 || repo.Name != "packwiz" || repo.FullName != "packwiz/packwiz" {
+			t.Errorf("got %+v, want ID=12345 Name=packwiz FullName=packwiz/packwiz", repo)
+		}
+	})
+
+	t.Run("rejects response with empty full_name", func(t *testing.T) {
+		httpmock.Activate(t)
+
+		// GitHub returns 200 OK with a partial body in some edge
+		// cases (e.g., the slug points at a path that isn't actually
+		// a repo). The function guards by requiring FullName to be
+		// non-empty.
+		httpmock.RegisterResponder("GET",
+			"https://api.github.com/repos/missing/repo",
+			httpmock.NewStringResponder(200, `{}`))
+
+		_, err := fetchRepo("missing/repo")
+		if err == nil {
+			t.Error("expected error for empty FullName, got nil")
+		}
+	})
+
+	t.Run("propagates non-200 status as error", func(t *testing.T) {
+		httpmock.Activate(t)
+
+		httpmock.RegisterResponder("GET",
+			"https://api.github.com/repos/nope/nope",
+			httpmock.NewStringResponder(404, `{"message":"Not Found"}`))
+
+		_, err := fetchRepo("nope/nope")
+		if err == nil {
+			t.Error("expected error for 404 response, got nil")
+		}
+	})
+}
+
+func TestGhUpdateData_ToMap_RoundTrip(t *testing.T) {
+	original := ghUpdateData{
+		Slug:   "packwiz/packwiz",
+		Tag:    "v1.0.0",
+		Branch: "main",
+		Regex:  `.*\.jar$`,
+	}
+
+	m, err := original.ToMap()
+	if err != nil {
+		t.Fatalf("ToMap: %v", err)
+	}
+
+	var back ghUpdateData
+	if err := mapstructure.Decode(m, &back); err != nil {
+		t.Fatalf("mapstructure.Decode: %v", err)
+	}
+
+	if !reflect.DeepEqual(back, original) {
+		t.Errorf("round-trip mismatch:\n  got:  %+v\n  want: %+v", back, original)
+	}
+}
+
+func TestAsset_GetSha256(t *testing.T) {
+	httpmock.Activate(t)
+
+	body := "binary jar contents would normally go here"
+
+	// Pre-compute the expected hash via the standard library so the
+	// test isn't pinning a copy-paste constant.
+	sum := sha256.Sum256([]byte(body))
+	want := hex.EncodeToString(sum[:])
+
+	const downloadURL = "https://github.com/owner/repo/releases/download/v1.0.0/asset.jar"
+
+	httpmock.RegisterResponder("GET", downloadURL,
+		httpmock.NewStringResponder(200, body))
+
+	asset := Asset{BrowserDownloadURL: downloadURL, Name: "asset.jar"}
+
+	got, err := asset.getSha256()
+	if err != nil {
+		t.Fatalf("getSha256: %v", err)
+	}
+
+	if got != want {
+		t.Errorf("getSha256 = %q, want %q", got, want)
+	}
+}

--- a/github/install_test.go
+++ b/github/install_test.go
@@ -1,0 +1,345 @@
+package github
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/packwiz/packwiz/core"
+)
+
+// newTestGithubMod writes a Mod TOML referencing the github update
+// plugin, then loads it through core.LoadMod so the registered
+// ghUpdater parses the update map.
+func newTestGithubMod(t *testing.T, name, filename, slug, tag, branch, regex string) *core.Mod {
+	t.Helper()
+
+	dir := t.TempDir()
+	modPath := filepath.Join(dir, "test.pw.toml")
+
+	contents := fmt.Sprintf(`name = %q
+filename = %q
+
+[download]
+url = "https://example.com/file.jar"
+hash-format = "sha256"
+hash = "deadbeef"
+
+[update]
+[update.github]
+slug = %q
+tag = %q
+branch = %q
+regex = %q
+`, name, filename, slug, tag, branch, regex)
+
+	if err := os.WriteFile(modPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	mod, err := core.LoadMod(modPath)
+	if err != nil {
+		t.Fatalf("LoadMod: %v", err)
+	}
+
+	return &mod
+}
+
+func TestGithubRegex(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		wantSlug  string
+		wantMatch bool
+	}{
+		{
+			name:      "plain URL",
+			input:     "https://github.com/packwiz/packwiz",
+			wantSlug:  "packwiz/packwiz",
+			wantMatch: true,
+		},
+		{
+			name:      "URL with www prefix",
+			input:     "https://www.github.com/packwiz/packwiz",
+			wantSlug:  "packwiz/packwiz",
+			wantMatch: true,
+		},
+		{
+			name:      "http (not https)",
+			input:     "http://github.com/packwiz/packwiz",
+			wantSlug:  "packwiz/packwiz",
+			wantMatch: true,
+		},
+		{
+			name:      "extra path segments are ignored after the slug",
+			input:     "https://github.com/packwiz/packwiz/releases/tag/v1.0",
+			wantSlug:  "packwiz/packwiz",
+			wantMatch: true,
+		},
+		{
+			name:      "not a github URL",
+			input:     "https://example.com/foo/bar",
+			wantMatch: false,
+		},
+		{
+			name:      "plain slug (no protocol) does not match",
+			input:     "packwiz/packwiz",
+			wantMatch: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matches := GithubRegex.FindStringSubmatch(tc.input)
+
+			gotMatch := len(matches) == 2
+			if gotMatch != tc.wantMatch {
+				t.Fatalf("match = %v, want %v", gotMatch, tc.wantMatch)
+			}
+
+			if tc.wantMatch && matches[1] != tc.wantSlug {
+				t.Errorf("slug = %q, want %q", matches[1], tc.wantSlug)
+			}
+		})
+	}
+}
+
+func TestGetLatestRelease(t *testing.T) {
+	const slug = "packwiz/packwiz"
+	const releasesURL = "https://api.github.com/repos/" + slug + "/releases"
+
+	t.Run("no branch returns the first release in the array", func(t *testing.T) {
+		httpmock.Activate(t)
+
+		body := `[
+			{"url":"r1", "tag_name":"v2.0.0", "target_commitish":"main", "name":"Two", "created_at":"2024-06-01T00:00:00Z", "assets":[]},
+			{"url":"r2", "tag_name":"v1.0.0", "target_commitish":"main", "name":"One", "created_at":"2024-01-01T00:00:00Z", "assets":[]}
+		]`
+
+		httpmock.RegisterResponder("GET", releasesURL,
+			httpmock.NewStringResponder(200, body))
+
+		release, err := getLatestRelease(slug, "")
+		if err != nil {
+			t.Fatalf("getLatestRelease: %v", err)
+		}
+
+		if release.TagName != "v2.0.0" {
+			t.Errorf("TagName = %q, want v2.0.0", release.TagName)
+		}
+	})
+
+	t.Run("branch filter returns the matching release", func(t *testing.T) {
+		httpmock.Activate(t)
+
+		body := `[
+			{"tag_name":"v2.0.0-main", "target_commitish":"main"},
+			{"tag_name":"v1.5.0-stable", "target_commitish":"stable"},
+			{"tag_name":"v1.0.0-stable", "target_commitish":"stable"}
+		]`
+
+		httpmock.RegisterResponder("GET", releasesURL,
+			httpmock.NewStringResponder(200, body))
+
+		release, err := getLatestRelease(slug, "stable")
+		if err != nil {
+			t.Fatalf("getLatestRelease: %v", err)
+		}
+
+		// The branch loop returns the FIRST match in the array, so
+		// v1.5.0-stable wins over v1.0.0-stable.
+		if release.TagName != "v1.5.0-stable" {
+			t.Errorf("TagName = %q, want v1.5.0-stable", release.TagName)
+		}
+	})
+
+	t.Run("branch with no match returns error", func(t *testing.T) {
+		httpmock.Activate(t)
+
+		body := `[
+			{"tag_name":"v1.0.0", "target_commitish":"main"}
+		]`
+
+		httpmock.RegisterResponder("GET", releasesURL,
+			httpmock.NewStringResponder(200, body))
+
+		_, err := getLatestRelease(slug, "nonexistent-branch")
+		if err == nil {
+			t.Error("expected error for branch with no matching release, got nil")
+		}
+	})
+}
+
+func TestGhUpdater_CheckUpdate(t *testing.T) {
+	const ghSlug = "owner/repo"
+	const releasesURL = "https://api.github.com/repos/" + ghSlug + "/releases"
+	const installedTag = "v1.0.0"
+
+	pack := core.Pack{
+		Versions: map[string]string{"minecraft": "1.20.1"},
+	}
+
+	t.Run("mod without github update data gets a per-mod error", func(t *testing.T) {
+		mod := &core.Mod{Name: "no-update", FileName: "test.jar"}
+
+		results, err := ghUpdater{}.CheckUpdate([]*core.Mod{mod}, pack)
+		if err != nil {
+			t.Fatalf("CheckUpdate returned overall error: %v", err)
+		}
+
+		if results[0].Error == nil {
+			t.Errorf("expected per-mod error, got %+v", results[0])
+		}
+	})
+
+	t.Run("same tag yields UpdateAvailable=false", func(t *testing.T) {
+		httpmock.Activate(t)
+
+		body := `[
+			{"tag_name":"v1.0.0", "target_commitish":"main", "assets":[{"name":"asset.jar"}]}
+		]`
+
+		httpmock.RegisterResponder("GET", releasesURL,
+			httpmock.NewStringResponder(200, body))
+
+		mod := newTestGithubMod(t, "Test", "asset.jar", ghSlug, installedTag, "", `^.+\.jar$`)
+
+		results, err := ghUpdater{}.CheckUpdate([]*core.Mod{mod}, pack)
+		if err != nil {
+			t.Fatalf("CheckUpdate: %v", err)
+		}
+
+		if results[0].Error != nil {
+			t.Fatalf("unexpected per-mod error: %v", results[0].Error)
+		}
+
+		if results[0].UpdateAvailable {
+			t.Errorf("expected UpdateAvailable=false, got %+v", results[0])
+		}
+	})
+
+	t.Run("new tag with single matching asset yields UpdateAvailable=true", func(t *testing.T) {
+		httpmock.Activate(t)
+
+		body := `[
+			{"tag_name":"v2.0.0", "target_commitish":"main", "assets":[
+				{"name":"asset-2.0.0.jar", "browser_download_url":"https://example.com/asset-2.0.0.jar"}
+			]}
+		]`
+
+		httpmock.RegisterResponder("GET", releasesURL,
+			httpmock.NewStringResponder(200, body))
+
+		mod := newTestGithubMod(t, "Test", "asset-1.0.0.jar", ghSlug, installedTag, "", `^.+\.jar$`)
+
+		results, err := ghUpdater{}.CheckUpdate([]*core.Mod{mod}, pack)
+		if err != nil {
+			t.Fatalf("CheckUpdate: %v", err)
+		}
+
+		if results[0].Error != nil {
+			t.Fatalf("unexpected per-mod error: %v", results[0].Error)
+		}
+
+		if !results[0].UpdateAvailable {
+			t.Fatalf("expected UpdateAvailable=true, got %+v", results[0])
+		}
+
+		want := "asset-1.0.0.jar -> asset-2.0.0.jar"
+		if results[0].UpdateString != want {
+			t.Errorf("UpdateString = %q, want %q", results[0].UpdateString, want)
+		}
+	})
+
+	t.Run("new release with no assets yields per-mod error", func(t *testing.T) {
+		httpmock.Activate(t)
+
+		body := `[
+			{"tag_name":"v2.0.0", "target_commitish":"main", "assets":[]}
+		]`
+
+		httpmock.RegisterResponder("GET", releasesURL,
+			httpmock.NewStringResponder(200, body))
+
+		mod := newTestGithubMod(t, "Test", "asset-1.0.0.jar", ghSlug, installedTag, "", `^.+\.jar$`)
+
+		results, err := ghUpdater{}.CheckUpdate([]*core.Mod{mod}, pack)
+		if err != nil {
+			t.Fatalf("CheckUpdate: %v", err)
+		}
+
+		if results[0].Error == nil {
+			t.Errorf("expected per-mod error for no-assets case, got %+v", results[0])
+		}
+	})
+
+	t.Run("new release with no regex-matching asset yields per-mod error", func(t *testing.T) {
+		httpmock.Activate(t)
+
+		body := `[
+			{"tag_name":"v2.0.0", "target_commitish":"main", "assets":[
+				{"name":"checksums.txt"}
+			]}
+		]`
+
+		httpmock.RegisterResponder("GET", releasesURL,
+			httpmock.NewStringResponder(200, body))
+
+		// Regex matches only .jar files; the asset is .txt.
+		mod := newTestGithubMod(t, "Test", "asset-1.0.0.jar", ghSlug, installedTag, "", `^.+\.jar$`)
+
+		results, err := ghUpdater{}.CheckUpdate([]*core.Mod{mod}, pack)
+		if err != nil {
+			t.Fatalf("CheckUpdate: %v", err)
+		}
+
+		if results[0].Error == nil {
+			t.Errorf("expected per-mod error for no-regex-match case, got %+v", results[0])
+		}
+	})
+
+	t.Run("new release with multiple regex-matching assets yields per-mod error", func(t *testing.T) {
+		httpmock.Activate(t)
+
+		body := `[
+			{"tag_name":"v2.0.0", "target_commitish":"main", "assets":[
+				{"name":"asset-a.jar"},
+				{"name":"asset-b.jar"}
+			]}
+		]`
+
+		httpmock.RegisterResponder("GET", releasesURL,
+			httpmock.NewStringResponder(200, body))
+
+		mod := newTestGithubMod(t, "Test", "asset-1.0.0.jar", ghSlug, installedTag, "", `^.+\.jar$`)
+
+		results, err := ghUpdater{}.CheckUpdate([]*core.Mod{mod}, pack)
+		if err != nil {
+			t.Fatalf("CheckUpdate: %v", err)
+		}
+
+		if results[0].Error == nil {
+			t.Errorf("expected per-mod error for multiple-matches case, got %+v", results[0])
+		}
+	})
+
+	t.Run("getLatestRelease error becomes a per-mod error", func(t *testing.T) {
+		httpmock.Activate(t)
+
+		httpmock.RegisterResponder("GET", releasesURL,
+			httpmock.NewStringResponder(500, `{"message":"boom"}`))
+
+		mod := newTestGithubMod(t, "Test", "asset-1.0.0.jar", ghSlug, installedTag, "", `^.+\.jar$`)
+
+		results, err := ghUpdater{}.CheckUpdate([]*core.Mod{mod}, pack)
+		if err != nil {
+			t.Fatalf("CheckUpdate returned overall error: %v", err)
+		}
+
+		if results[0].Error == nil {
+			t.Errorf("expected per-mod error from 500 response, got %+v", results[0])
+		}
+	})
+}

--- a/github/updater_test.go
+++ b/github/updater_test.go
@@ -1,0 +1,52 @@
+package github
+
+import "testing"
+
+func TestGhUpdater_ParseUpdate(t *testing.T) {
+	in := map[string]interface{}{
+		"slug":   "packwiz/packwiz",
+		"tag":    "v1.0.0",
+		"branch": "main",
+		"regex":  `.*\.jar$`,
+	}
+
+	u := ghUpdater{}
+	got, err := u.ParseUpdate(in)
+	if err != nil {
+		t.Fatalf("ParseUpdate: %v", err)
+	}
+
+	data, ok := got.(ghUpdateData)
+	if !ok {
+		t.Fatalf("ParseUpdate returned %T, want ghUpdateData", got)
+	}
+
+	if data.Slug != "packwiz/packwiz" || data.Tag != "v1.0.0" ||
+		data.Branch != "main" || data.Regex != `.*\.jar$` {
+		t.Errorf("got %+v, want all four fields populated from input map", data)
+	}
+}
+
+func TestGhUpdater_ParseUpdate_MissingFieldsAreZero(t *testing.T) {
+	// Partial input maps decode cleanly with the missing fields
+	// defaulting to zero values — that's mapstructure's standard
+	// behavior. Pinning so a future migration to a stricter decoder
+	// (DisallowUnknownFields, ErrorUnused, etc.) surfaces here.
+	in := map[string]interface{}{
+		"slug": "packwiz/packwiz",
+	}
+
+	got, err := ghUpdater{}.ParseUpdate(in)
+	if err != nil {
+		t.Fatalf("ParseUpdate: %v", err)
+	}
+
+	data := got.(ghUpdateData)
+	if data.Slug != "packwiz/packwiz" {
+		t.Errorf("Slug = %q, want packwiz/packwiz", data.Slug)
+	}
+
+	if data.Tag != "" || data.Branch != "" || data.Regex != "" {
+		t.Errorf("missing fields were not zero: %+v", data)
+	}
+}

--- a/migrate/loader_test.go
+++ b/migrate/loader_test.go
@@ -1,0 +1,68 @@
+package migrate
+
+import (
+	"testing"
+
+	"github.com/packwiz/packwiz/core"
+)
+
+// validateVersion and the surrounding loader command both call
+// os.Exit(1) on failure paths, so only the success paths are
+// exercised here. See .claude/TODO.md ("Audit and improve error
+// handling") for the broader refactor — these helpers should return
+// errors rather than calling os.Exit directly.
+
+func TestValidateVersion_Success(t *testing.T) {
+	versions := []string{"0.14.21", "0.15.0", "0.15.3"}
+	loader := core.ModLoaderComponent{Name: "fabric", FriendlyName: "Fabric"}
+
+	for _, v := range versions {
+		t.Run(v, func(t *testing.T) {
+			// Should return silently. A regression would terminate
+			// the test process via os.Exit(1).
+			validateVersion(versions, v, loader)
+		})
+	}
+}
+
+func TestUpdatePackToVersion(t *testing.T) {
+	loader := core.ModLoaderComponent{Name: "fabric", FriendlyName: "Fabric"}
+
+	t.Run("new version replaces the old one and returns true", func(t *testing.T) {
+		pack := core.Pack{
+			Versions: map[string]string{"fabric": "0.14.21", "minecraft": "1.20.1"},
+		}
+
+		ok := updatePackToVersion("0.15.3", pack, loader)
+		if !ok {
+			t.Fatal("expected true when version differed, got false")
+		}
+
+		// The function takes pack by value, but Versions is a map
+		// (reference semantics), so the mutation is visible to the
+		// caller.
+		if got := pack.Versions["fabric"]; got != "0.15.3" {
+			t.Errorf("pack.Versions[fabric] = %q, want %q", got, "0.15.3")
+		}
+
+		// Unrelated entries are untouched.
+		if got := pack.Versions["minecraft"]; got != "1.20.1" {
+			t.Errorf("pack.Versions[minecraft] = %q, want %q (should be untouched)", got, "1.20.1")
+		}
+	})
+
+	t.Run("identical version is a no-op and returns false", func(t *testing.T) {
+		pack := core.Pack{
+			Versions: map[string]string{"fabric": "0.15.3"},
+		}
+
+		ok := updatePackToVersion("0.15.3", pack, loader)
+		if ok {
+			t.Errorf("expected false when version already matched, got true")
+		}
+
+		if got := pack.Versions["fabric"]; got != "0.15.3" {
+			t.Errorf("pack.Versions[fabric] = %q, want %q (should be unchanged)", got, "0.15.3")
+		}
+	})
+}

--- a/modrinth/modrinth_test.go
+++ b/modrinth/modrinth_test.go
@@ -1,0 +1,1021 @@
+package modrinth
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+
+	modrinthApi "codeberg.org/jmansfield/go-modrinth/modrinth"
+	"github.com/jarcoal/httpmock"
+	"github.com/packwiz/packwiz/core"
+	"github.com/spf13/viper"
+)
+
+func sptr(s string) *string { return &s }
+
+// newTestModrinthMod writes a Mod TOML to a temp file and loads it
+// through core.LoadMod, which exercises the modrinth init() updater
+// registration so [update.modrinth] decode happens normally.
+func newTestModrinthMod(t *testing.T, name, filename, projectID, versionID string) *core.Mod {
+	t.Helper()
+
+	dir := t.TempDir()
+	modPath := filepath.Join(dir, "test.pw.toml")
+
+	contents := fmt.Sprintf(`name = %q
+filename = %q
+
+[download]
+url = "https://example.com/file.jar"
+hash-format = "sha1"
+hash = "deadbeef"
+
+[update]
+[update.modrinth]
+mod-id = %q
+version = %q
+`, name, filename, projectID, versionID)
+
+	if err := os.WriteFile(modPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	mod, err := core.LoadMod(modPath)
+	if err != nil {
+		t.Fatalf("LoadMod: %v", err)
+	}
+
+	return &mod
+}
+
+func TestShouldDownloadOnSide(t *testing.T) {
+	cases := []struct {
+		side string
+		want bool
+	}{
+		{"required", true},
+		{"optional", true},
+		{"unsupported", false},
+		{"", false},
+		{"unknown-value", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.side, func(t *testing.T) {
+			if got := shouldDownloadOnSide(tc.side); got != tc.want {
+				t.Errorf("shouldDownloadOnSide(%q) = %v, want %v", tc.side, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetSide(t *testing.T) {
+	cases := []struct {
+		name       string
+		serverSide string
+		clientSide string
+		want       string
+	}{
+		{"required on both", "required", "required", "both"},
+		{"optional on both", "optional", "optional", "both"},
+		{"server only", "required", "unsupported", "server"},
+		{"client only", "unsupported", "required", "client"},
+		{"unsupported on both", "unsupported", "unsupported", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			project := &modrinthApi.Project{
+				ServerSide: sptr(tc.serverSide),
+				ClientSide: sptr(tc.clientSide),
+			}
+
+			if got := getSide(project); got != tc.want {
+				t.Errorf("getSide = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetBestHash(t *testing.T) {
+	t.Run("sha512 wins over weaker hashes", func(t *testing.T) {
+		f := &modrinthApi.File{Hashes: map[string]string{
+			"sha512": "z", "sha256": "y", "sha1": "x", "murmur2": "w",
+		}}
+
+		gotFmt, gotVal := getBestHash(f)
+		if gotFmt != "sha512" || gotVal != "z" {
+			t.Errorf("got (%q, %q), want (sha512, z)", gotFmt, gotVal)
+		}
+	})
+
+	t.Run("sha256 picked when sha512 absent", func(t *testing.T) {
+		f := &modrinthApi.File{Hashes: map[string]string{"sha256": "v", "sha1": "u"}}
+
+		gotFmt, gotVal := getBestHash(f)
+		if gotFmt != "sha256" || gotVal != "v" {
+			t.Errorf("got (%q, %q), want (sha256, v)", gotFmt, gotVal)
+		}
+	})
+
+	t.Run("sha1 picked when only sha1 and murmur2 present", func(t *testing.T) {
+		f := &modrinthApi.File{Hashes: map[string]string{"sha1": "s", "murmur2": "m"}}
+
+		gotFmt, gotVal := getBestHash(f)
+		if gotFmt != "sha1" || gotVal != "s" {
+			t.Errorf("got (%q, %q), want (sha1, s)", gotFmt, gotVal)
+		}
+	})
+
+	t.Run("murmur2 picked when preferred hashes absent", func(t *testing.T) {
+		f := &modrinthApi.File{Hashes: map[string]string{"murmur2": "m"}}
+
+		gotFmt, gotVal := getBestHash(f)
+		if gotFmt != "murmur2" || gotVal != "m" {
+			t.Errorf("got (%q, %q), want (murmur2, m)", gotFmt, gotVal)
+		}
+	})
+
+	t.Run("empty hashes return empty strings", func(t *testing.T) {
+		f := &modrinthApi.File{Hashes: map[string]string{}}
+
+		gotFmt, gotVal := getBestHash(f)
+		if gotFmt != "" || gotVal != "" {
+			t.Errorf("got (%q, %q), want (\"\", \"\")", gotFmt, gotVal)
+		}
+	})
+}
+
+func TestCompareLoaderLists(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b []string
+		want int32
+	}{
+		{
+			name: "both empty",
+			a:    nil, b: nil,
+			want: 0,
+		},
+		{
+			name: "quilt beats fabric",
+			a:    []string{"quilt"}, b: []string{"fabric"},
+			want: -1,
+		},
+		{
+			name: "fabric loses to quilt",
+			a:    []string{"fabric"}, b: []string{"quilt"},
+			want: 1,
+		},
+		{
+			name: "neoforge beats forge",
+			a:    []string{"neoforge"}, b: []string{"forge"},
+			want: -1,
+		},
+		{
+			// Both lists contain "fabric"; compat group makes "quilt"
+			// irrelevant for the comparison, so A and B compare equal.
+			name: "quilt+fabric vs fabric -> equal via compat group",
+			a:    []string{"quilt", "fabric"}, b: []string{"fabric"},
+			want: 0,
+		},
+		{
+			// Both lists contain "forge"; "neoforge" enters the compat
+			// group and is ignored, leaving forge on both sides.
+			name: "forge vs forge+neoforge -> equal via compat group",
+			a:    []string{"forge"}, b: []string{"forge", "neoforge"},
+			want: 0,
+		},
+		{
+			// PR #391 territory: a multi-loader version that includes
+			// fabric beats a neoforge-only version, even when the
+			// consumer pack is neoforge-only — because this function
+			// has no view of the pack's loaders. Pinning current
+			// behavior; the fix (in upstream PR #391) is in the
+			// CALLER, not here.
+			name: "PR #391 baseline: fabric-bearing list wins regardless of pack loaders",
+			a:    []string{"fabric", "forge", "neoforge"}, b: []string{"neoforge"},
+			want: -1,
+		},
+		{
+			name: "non-empty vs empty -> non-empty wins",
+			a:    []string{"fabric"}, b: nil,
+			want: -1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := compareLoaderLists(tc.a, tc.b); got != tc.want {
+				t.Errorf("compareLoaderLists(%v, %v) = %d, want %d", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetProjectTypeFolder(t *testing.T) {
+	// Ensure viper datapack-folder is unset for this test's lifetime;
+	// none of the cases below need it, and a leak from another test
+	// could mask the "datapack" branch behavior.
+	t.Cleanup(func() { viper.Set("datapack-folder", "") })
+	viper.Set("datapack-folder", "")
+
+	cases := []struct {
+		name         string
+		projectType  string
+		fileLoaders  []string
+		packLoaders  []string
+		want         string
+		wantErr      bool
+	}{
+		{
+			name:        "modpack always errors",
+			projectType: "modpack",
+			wantErr:     true,
+		},
+		{
+			name:        "resourcepack always returns resourcepacks",
+			projectType: "resourcepack",
+			want:        "resourcepacks",
+		},
+		{
+			name:        "shader with iris loader goes to shaderpacks",
+			projectType: "shader",
+			fileLoaders: []string{"iris"},
+			want:        "shaderpacks",
+		},
+		{
+			// canvas is in loaderFolders as "resourcepacks" (core
+			// shaders ship as resource packs); the function honors
+			// that mapping for shader projects too.
+			name:        "shader with canvas loader goes to resourcepacks",
+			projectType: "shader",
+			fileLoaders: []string{"canvas"},
+			want:        "resourcepacks",
+		},
+		{
+			name:        "shader with unknown loader falls back to shaderpacks",
+			projectType: "shader",
+			fileLoaders: []string{"unknown-loader"},
+			want:        "shaderpacks",
+		},
+		{
+			name:        "mod with overlapping fabric loader goes to mods",
+			projectType: "mod",
+			fileLoaders: []string{"fabric"},
+			packLoaders: []string{"fabric"},
+			want:        "mods",
+		},
+		{
+			name:        "mod with no overlap falls back to mods",
+			projectType: "mod",
+			fileLoaders: []string{"fabric"},
+			packLoaders: []string{"forge"},
+			want:        "mods",
+		},
+		{
+			name:        "unknown project type errors",
+			projectType: "data-pack",
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := getProjectTypeFolder(tc.projectType, tc.fileLoaders, tc.packLoaders)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error for project type %q, got nil (result: %q)", tc.projectType, got)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseSlugOrUrl(t *testing.T) {
+	cases := []struct {
+		name          string
+		input         string
+		wantSlug      string
+		wantVersion   string
+		wantVersionID string
+		wantFilename  string
+		wantParsed    bool
+		wantErr       bool
+	}{
+		{
+			name:     "modrinth URL with project category and slug",
+			input:    "https://modrinth.com/mod/sodium",
+			wantSlug: "sodium",
+		},
+		{
+			name:        "modrinth URL with slug and version",
+			input:       "https://modrinth.com/mod/sodium/version/mc1.20.1",
+			wantSlug:    "sodium",
+			wantVersion: "mc1.20.1",
+		},
+		{
+			name:          "CDN URL extracts id + versionID + filename",
+			input:         "https://cdn.modrinth.com/data/abc123/versions/def456/sodium.jar",
+			wantSlug:      "abc123",
+			wantVersionID: "def456",
+			wantFilename:  "sodium.jar",
+		},
+		{
+			name:    "modrinth URL with unknown category returns error",
+			input:   "https://modrinth.com/unknowncategory/sodium",
+			wantErr: true,
+		},
+		{
+			name:       "plain slug sets parsedSlug=true",
+			input:      "sodium",
+			wantSlug:   "sodium",
+			wantParsed: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var slug, version, versionID, filename string
+			parsed, err := parseSlugOrUrl(tc.input, &slug, &version, &versionID, &filename)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if slug != tc.wantSlug {
+				t.Errorf("slug = %q, want %q", slug, tc.wantSlug)
+			}
+
+			if version != tc.wantVersion {
+				t.Errorf("version = %q, want %q", version, tc.wantVersion)
+			}
+
+			if versionID != tc.wantVersionID {
+				t.Errorf("versionID = %q, want %q", versionID, tc.wantVersionID)
+			}
+
+			if filename != tc.wantFilename {
+				t.Errorf("filename = %q, want %q", filename, tc.wantFilename)
+			}
+
+			if parsed != tc.wantParsed {
+				t.Errorf("parsedSlug = %v, want %v", parsed, tc.wantParsed)
+			}
+		})
+	}
+}
+
+func TestMapDepOverride(t *testing.T) {
+	cases := []struct {
+		name      string
+		depID     string
+		isQuilt   bool
+		mcVersion string
+		want      string
+	}{
+		{
+			name:      "FAPI ID under Quilt maps to QFAPI/QSL",
+			depID:     "P7dR8mSH",
+			isQuilt:   true,
+			mcVersion: "1.20.1",
+			want:      "qvIfYCYJ",
+		},
+		{
+			name:      "FAPI by slug under Quilt also maps",
+			depID:     "fabric-api",
+			isQuilt:   true,
+			mcVersion: "1.20.1",
+			want:      "qvIfYCYJ",
+		},
+		{
+			name:      "FAPI under Fabric (not Quilt) is left alone",
+			depID:     "P7dR8mSH",
+			isQuilt:   false,
+			mcVersion: "1.20.1",
+			want:      "P7dR8mSH",
+		},
+		{
+			name:      "FLK under Quilt on 1.20.1 maps to QKL",
+			depID:     "Ha28R6CL",
+			isQuilt:   true,
+			mcVersion: "1.20.1",
+			want:      "lwVhp9o5",
+		},
+		{
+			name:      "FLK under Quilt on 1.18.2 is left alone (below 1.19.2)",
+			depID:     "Ha28R6CL",
+			isQuilt:   true,
+			mcVersion: "1.18.2",
+			want:      "Ha28R6CL",
+		},
+		{
+			name:      "unrelated dep ID is left alone",
+			depID:     "abcdef",
+			isQuilt:   true,
+			mcVersion: "1.20.1",
+			want:      "abcdef",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mapDepOverride(tc.depID, tc.isQuilt, tc.mcVersion); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// mrVersion is a small builder for *modrinthApi.Version fixtures used
+// by the findLatestVersion tests. Each call allocates fresh backing
+// strings/times so independent fixtures don't alias one another.
+func mrVersion(versionNumber string, gameVersions, loaders []string, date time.Time) *modrinthApi.Version {
+	vn := versionNumber
+	d := date
+
+	return &modrinthApi.Version{
+		VersionNumber: &vn,
+		GameVersions:  gameVersions,
+		Loaders:       loaders,
+		DatePublished: &d,
+	}
+}
+
+func TestFindLatestVersion_SingleVersionPassesThrough(t *testing.T) {
+	only := mrVersion("1.0.0", []string{"1.20.1"}, []string{"fabric"}, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	got := findLatestVersion([]*modrinthApi.Version{only}, []string{"1.20.1"}, false)
+	if got != only {
+		t.Errorf("expected the only version to be returned, got a different pointer")
+	}
+}
+
+func TestFindLatestVersion_LaterDateWinsWhenOthersEqual(t *testing.T) {
+	// Same version number, game version, loaders — only DatePublished
+	// differs. Newer date should win regardless of ordering.
+	older := mrVersion("1.0.0", []string{"1.20.1"}, []string{"fabric"}, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	newer := mrVersion("1.0.0", []string{"1.20.1"}, []string{"fabric"}, time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC))
+
+	t.Run("older first", func(t *testing.T) {
+		got := findLatestVersion([]*modrinthApi.Version{older, newer}, []string{"1.20.1"}, false)
+		if got != newer {
+			t.Errorf("expected newer version, got %q", *got.VersionNumber)
+		}
+	})
+
+	t.Run("newer first", func(t *testing.T) {
+		got := findLatestVersion([]*modrinthApi.Version{newer, older}, []string{"1.20.1"}, false)
+		if got != newer {
+			t.Errorf("expected newer version, got %q", *got.VersionNumber)
+		}
+	})
+}
+
+func TestFindLatestVersion_HigherGameVersionIndexWins(t *testing.T) {
+	// packVersions list semantics: later entries are preferred (the
+	// "main" MC version comes last). A version that targets the later
+	// entry should beat one that only targets the earlier entry, even
+	// when published earlier.
+	packVersions := []string{"1.19.4", "1.20.1"}
+
+	olderButNewerMC := mrVersion("1.0.0", []string{"1.20.1"}, []string{"fabric"}, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	newerButOlderMC := mrVersion("2.0.0", []string{"1.19.4"}, []string{"fabric"}, time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC))
+
+	got := findLatestVersion([]*modrinthApi.Version{newerButOlderMC, olderButNewerMC}, packVersions, false)
+	if got != olderButNewerMC {
+		t.Errorf("expected the 1.20.1-targeting version to win on game-version index; got %q with MCs %v",
+			*got.VersionNumber, got.GameVersions)
+	}
+}
+
+func TestFindLatestVersion_FlexVerOverridesDate(t *testing.T) {
+	// With useFlexVer=true, the version-number compare runs first.
+	// A newer flexver beats an older flexver regardless of publish date.
+	oldFlexVerNewDate := mrVersion("1.0.0", []string{"1.20.1"}, []string{"fabric"}, time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC))
+	newFlexVerOldDate := mrVersion("2.0.0", []string{"1.20.1"}, []string{"fabric"}, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	got := findLatestVersion([]*modrinthApi.Version{oldFlexVerNewDate, newFlexVerOldDate}, []string{"1.20.1"}, true)
+	if got != newFlexVerOldDate {
+		t.Errorf("expected newer-flexver version to win when useFlexVer=true; got %q",
+			*got.VersionNumber)
+	}
+}
+
+func TestFindLatestVersion_LoaderPreference_QuiltOverFabric(t *testing.T) {
+	// Identical date and game version; quilt should win over fabric
+	// per loaderPreferenceList.
+	date := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	fabricOnly := mrVersion("1.0.0", []string{"1.20.1"}, []string{"fabric"}, date)
+	quiltOnly := mrVersion("1.0.0", []string{"1.20.1"}, []string{"quilt"}, date)
+
+	got := findLatestVersion([]*modrinthApi.Version{fabricOnly, quiltOnly}, []string{"1.20.1"}, false)
+	if got != quiltOnly {
+		t.Errorf("expected quilt version to win loader preference; got %v", got.Loaders)
+	}
+}
+
+func TestFindLatestVersion_PR391Baseline_LoaderListCompareIsPackUnaware(t *testing.T) {
+	// PR #391 baseline: findLatestVersion calls compareLoaderLists
+	// without filtering each version's loader list to only those
+	// relevant to the consumer pack. So a multi-loader version
+	// that includes "fabric" can beat a "neoforge"-only version
+	// even when the pack is neoforge-only — because fabric ranks
+	// ahead of neoforge in loaderPreferenceList.
+	//
+	// The fix proposed in upstream PR #391 filters each version's
+	// loader list to only pack-relevant loaders before comparison.
+	// When that lands, this test breaks and the behavior we're
+	// pinning will need to be revisited. See .claude/TODO.md for
+	// the matched companion task on the CurseForge side.
+	date := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	multiLoader := mrVersion("5.0.2", []string{"1.20.1"}, []string{"fabric", "forge", "neoforge"}, date)
+	neoforgeOnly := mrVersion("5.4.6.1", []string{"1.20.1"}, []string{"neoforge"}, date)
+
+	// useFlexVer=false so version-number doesn't break the tie.
+	got := findLatestVersion([]*modrinthApi.Version{multiLoader, neoforgeOnly}, []string{"1.20.1"}, false)
+	if got != multiLoader {
+		t.Errorf("baseline pin violated: expected multiLoader (fabric-bearing) to win; got %q", *got.VersionNumber)
+	}
+}
+
+// projectIDPtr / versionPtr / boolPtr just keep the resolveVersion
+// and getLatestVersion test fixtures readable.
+func strPtr(s string) *string { return &s }
+
+func TestResolveVersion_VersionIDInProjectVersionList(t *testing.T) {
+	// When the requested version string is present in project.Versions,
+	// resolveVersion treats it as an ID and does a single Versions.Get.
+	httpmock.Activate(t)
+
+	const projectID = "AANobbMI"
+	const versionID = "gqoXgtxO"
+
+	body := `{
+		"id": "gqoXgtxO",
+		"project_id": "AANobbMI",
+		"name": "Test 1.0.0",
+		"version_number": "1.0.0",
+		"game_versions": ["1.20.1"],
+		"loaders": ["fabric"],
+		"date_published": "2024-01-15T00:00:00Z",
+		"files": []
+	}`
+
+	httpmock.RegisterResponder("GET",
+		"https://api.modrinth.com/v2/version/"+versionID,
+		httpmock.NewStringResponder(200, body))
+
+	project := &modrinthApi.Project{
+		ID:       strPtr(projectID),
+		Versions: []string{versionID, "anotherVerID"},
+	}
+
+	got, err := resolveVersion(project, versionID)
+	if err != nil {
+		t.Fatalf("resolveVersion: %v", err)
+	}
+
+	if got.ID == nil || *got.ID != versionID {
+		t.Errorf("ID = %v, want %q", got.ID, versionID)
+	}
+
+	if got.VersionNumber == nil || *got.VersionNumber != "1.0.0" {
+		t.Errorf("VersionNumber = %v, want \"1.0.0\"", got.VersionNumber)
+	}
+}
+
+func TestResolveVersion_FallbackToVersionNumberLookup(t *testing.T) {
+	// When the input isn't a known version ID, resolveVersion lists
+	// all versions and finds the one with a matching version_number.
+	// The traversal is in reverse order so the OLDEST matching entry
+	// wins (per the function's comment about Modrinth knossos
+	// behavior).
+	httpmock.Activate(t)
+
+	const projectID = "AANobbMI"
+
+	body := `[
+		{"id": "newID", "version_number": "1.0.0", "name": "newer dup"},
+		{"id": "oldID", "version_number": "1.0.0", "name": "older dup"}
+	]`
+
+	httpmock.RegisterRegexpResponder("GET",
+		regexp.MustCompile(`^https://api\.modrinth\.com/v2/project/`+projectID+`/version`),
+		httpmock.NewStringResponder(200, body))
+
+	project := &modrinthApi.Project{
+		ID:       strPtr(projectID),
+		Versions: []string{"newID", "oldID"},
+	}
+
+	// "1.0.0" is not in Versions (only IDs are), so the function falls
+	// through to ListVersions.
+	got, err := resolveVersion(project, "1.0.0")
+	if err != nil {
+		t.Fatalf("resolveVersion: %v", err)
+	}
+
+	// Reverse traversal: the function iterates from len-1 down. The
+	// last matching entry it encounters wins, which is the FIRST entry
+	// of the list since they both match — so we get "newID".
+	// Wait: iterating from index 1 (oldID) downward, the function
+	// returns the FIRST match it finds, which is oldID at index 1.
+	// (The comment in the function says Modrinth returns the oldest
+	// file precedence-style, so the function reverses to undo that.)
+	if got.ID == nil || *got.ID != "oldID" {
+		t.Errorf("ID = %v, want \"oldID\" (reverse-iteration picks the highest-index match first)", got.ID)
+	}
+}
+
+func TestResolveVersion_NotFound(t *testing.T) {
+	httpmock.Activate(t)
+
+	const projectID = "AANobbMI"
+
+	body := `[
+		{"id": "abc", "version_number": "1.0.0"},
+		{"id": "def", "version_number": "2.0.0"}
+	]`
+
+	httpmock.RegisterRegexpResponder("GET",
+		regexp.MustCompile(`^https://api\.modrinth\.com/v2/project/`+projectID+`/version`),
+		httpmock.NewStringResponder(200, body))
+
+	project := &modrinthApi.Project{
+		ID:       strPtr(projectID),
+		Versions: []string{"abc", "def"},
+	}
+
+	_, err := resolveVersion(project, "9.9.9")
+	if err == nil {
+		t.Error("expected error when version number is not found, got nil")
+	}
+}
+
+func TestGetLatestVersion_HappyPath(t *testing.T) {
+	httpmock.Activate(t)
+
+	t.Cleanup(func() {
+		viper.Set("acceptable-game-versions", nil)
+		viper.Set("datapack-folder", "")
+	})
+	viper.Set("acceptable-game-versions", nil)
+	viper.Set("datapack-folder", "")
+
+	const projectID = "AANobbMI"
+
+	// Two versions, both target 1.20.1+fabric; the second was
+	// published later so findLatestVersion should pick it.
+	body := `[
+		{
+			"id": "olderID",
+			"version_number": "1.0.0",
+			"game_versions": ["1.20.1"],
+			"loaders": ["fabric"],
+			"date_published": "2024-01-15T00:00:00Z",
+			"files": []
+		},
+		{
+			"id": "newerID",
+			"version_number": "1.0.1",
+			"game_versions": ["1.20.1"],
+			"loaders": ["fabric"],
+			"date_published": "2024-06-15T00:00:00Z",
+			"files": []
+		}
+	]`
+
+	httpmock.RegisterRegexpResponder("GET",
+		regexp.MustCompile(`^https://api\.modrinth\.com/v2/project/`+projectID+`/version`),
+		httpmock.NewStringResponder(200, body))
+
+	pack := core.Pack{
+		Versions: map[string]string{
+			"minecraft": "1.20.1",
+			"fabric":    "0.15.0",
+		},
+	}
+
+	got, err := getLatestVersion(projectID, "Test Mod", pack)
+	if err != nil {
+		t.Fatalf("getLatestVersion: %v", err)
+	}
+
+	if got.ID == nil || *got.ID != "newerID" {
+		t.Errorf("picked ID = %v, want \"newerID\"", got.ID)
+	}
+}
+
+func TestGetLatestVersion_NoVersionsError(t *testing.T) {
+	httpmock.Activate(t)
+
+	t.Cleanup(func() {
+		viper.Set("acceptable-game-versions", nil)
+		viper.Set("datapack-folder", "")
+	})
+	viper.Set("acceptable-game-versions", nil)
+	viper.Set("datapack-folder", "")
+
+	const projectID = "AANobbMI"
+
+	httpmock.RegisterRegexpResponder("GET",
+		regexp.MustCompile(`^https://api\.modrinth\.com/v2/project/`+projectID+`/version`),
+		httpmock.NewStringResponder(200, `[]`))
+
+	pack := core.Pack{
+		Versions: map[string]string{
+			"minecraft": "1.20.1",
+			"fabric":    "0.15.0",
+		},
+	}
+
+	_, err := getLatestVersion(projectID, "Test Mod", pack)
+	if err == nil {
+		t.Error("expected error when API returns empty version list, got nil")
+	}
+}
+
+func TestMrUpdateData_ToMap_RoundTrip(t *testing.T) {
+	original := mrUpdateData{
+		ProjectID:        "AANobbMI",
+		InstalledVersion: "gqoXgtxO",
+	}
+
+	m, err := original.ToMap()
+	if err != nil {
+		t.Fatalf("ToMap: %v", err)
+	}
+
+	// The mapstructure tags map to "mod-id" and "version" rather
+	// than the field names. Pin those here so a future tag rename
+	// (the source has // TODO(format): change to ... comments)
+	// surfaces in tests.
+	if m["mod-id"] != "AANobbMI" {
+		t.Errorf("ToMap key mod-id = %v, want AANobbMI", m["mod-id"])
+	}
+
+	if m["version"] != "gqoXgtxO" {
+		t.Errorf("ToMap key version = %v, want gqoXgtxO", m["version"])
+	}
+
+	parsed, err := mrUpdater{}.ParseUpdate(m)
+	if err != nil {
+		t.Fatalf("ParseUpdate: %v", err)
+	}
+
+	if parsed.(mrUpdateData) != original {
+		t.Errorf("round-trip mismatch:\n  got:  %+v\n  want: %+v", parsed, original)
+	}
+}
+
+func TestMrUpdater_ParseUpdate(t *testing.T) {
+	in := map[string]interface{}{
+		"mod-id":  "AANobbMI",
+		"version": "gqoXgtxO",
+	}
+
+	parsed, err := mrUpdater{}.ParseUpdate(in)
+	if err != nil {
+		t.Fatalf("ParseUpdate: %v", err)
+	}
+
+	data, ok := parsed.(mrUpdateData)
+	if !ok {
+		t.Fatalf("ParseUpdate returned %T, want mrUpdateData", parsed)
+	}
+
+	if data.ProjectID != "AANobbMI" || data.InstalledVersion != "gqoXgtxO" {
+		t.Errorf("got %+v, want mod-id=AANobbMI version=gqoXgtxO", data)
+	}
+}
+
+func TestGetProjectIdsViaSearch(t *testing.T) {
+	httpmock.Activate(t)
+
+	body := `{
+		"hits": [
+			{"slug": "sodium", "title": "Sodium", "project_id": "AANobbMI"},
+			{"slug": "iris", "title": "Iris", "project_id": "YL57xq9U"}
+		],
+		"offset": 0,
+		"limit": 5,
+		"total_hits": 2
+	}`
+
+	httpmock.RegisterRegexpResponder("GET",
+		regexp.MustCompile(`^https://api\.modrinth\.com/v2/search`),
+		httpmock.NewStringResponder(200, body))
+
+	hits, err := getProjectIdsViaSearch("performance", []string{"1.20.1"})
+	if err != nil {
+		t.Fatalf("getProjectIdsViaSearch: %v", err)
+	}
+
+	if len(hits) != 2 {
+		t.Fatalf("got %d hits, want 2", len(hits))
+	}
+
+	wantSlugs := []string{"sodium", "iris"}
+	for i, h := range hits {
+		if h.Slug == nil || *h.Slug != wantSlugs[i] {
+			t.Errorf("hits[%d].Slug = %v, want %q", i, h.Slug, wantSlugs[i])
+		}
+	}
+
+	wantIDs := []string{"AANobbMI", "YL57xq9U"}
+	for i, h := range hits {
+		if h.ProjectID == nil || *h.ProjectID != wantIDs[i] {
+			t.Errorf("hits[%d].ProjectID = %v, want %q", i, h.ProjectID, wantIDs[i])
+		}
+	}
+}
+
+func TestMrUpdater_CheckUpdate(t *testing.T) {
+	const projectID = "AANobbMI"
+	const installedVersion = "oldVersion"
+	const newVersionID = "newVersion"
+
+	pack := core.Pack{
+		Versions: map[string]string{
+			"minecraft": "1.20.1",
+			"fabric":    "0.15.0",
+		},
+	}
+
+	registerCleanup := func(t *testing.T) {
+		t.Helper()
+		t.Cleanup(func() {
+			viper.Set("acceptable-game-versions", nil)
+			viper.Set("datapack-folder", "")
+		})
+		viper.Set("acceptable-game-versions", nil)
+		viper.Set("datapack-folder", "")
+	}
+
+	t.Run("mod without modrinth update data gets a per-mod error", func(t *testing.T) {
+		// Construct a Mod directly without going through LoadMod, so
+		// updateData stays empty and GetParsedUpdateData misses.
+		mod := &core.Mod{Name: "no-update", FileName: "test.jar"}
+
+		results, err := mrUpdater{}.CheckUpdate([]*core.Mod{mod}, pack)
+		if err != nil {
+			t.Fatalf("CheckUpdate returned overall error: %v", err)
+		}
+
+		if len(results) != 1 {
+			t.Fatalf("got %d results, want 1", len(results))
+		}
+
+		if results[0].Error == nil {
+			t.Errorf("expected per-mod error, got %+v", results[0])
+		}
+	})
+
+	t.Run("installed version equals latest yields UpdateAvailable=false", func(t *testing.T) {
+		httpmock.Activate(t)
+		registerCleanup(t)
+
+		body := fmt.Sprintf(`[{
+			"id": %q,
+			"version_number": "1.0.0",
+			"game_versions": ["1.20.1"],
+			"loaders": ["fabric"],
+			"date_published": "2024-01-15T00:00:00Z",
+			"files": []
+		}]`, installedVersion)
+
+		httpmock.RegisterRegexpResponder("GET",
+			regexp.MustCompile(`^https://api\.modrinth\.com/v2/project/`+projectID+`/version`),
+			httpmock.NewStringResponder(200, body))
+
+		mod := newTestModrinthMod(t, "Test Mod", "old.jar", projectID, installedVersion)
+
+		results, err := mrUpdater{}.CheckUpdate([]*core.Mod{mod}, pack)
+		if err != nil {
+			t.Fatalf("CheckUpdate: %v", err)
+		}
+
+		if results[0].Error != nil {
+			t.Fatalf("unexpected per-mod error: %v", results[0].Error)
+		}
+
+		if results[0].UpdateAvailable {
+			t.Errorf("expected UpdateAvailable=false, got result %+v", results[0])
+		}
+	})
+
+	t.Run("newer version available with primary file", func(t *testing.T) {
+		httpmock.Activate(t)
+		registerCleanup(t)
+
+		body := fmt.Sprintf(`[{
+			"id": %q,
+			"version_number": "2.0.0",
+			"game_versions": ["1.20.1"],
+			"loaders": ["fabric"],
+			"date_published": "2024-06-15T00:00:00Z",
+			"files": [
+				{"filename": "secondary.jar", "primary": false},
+				{"filename": "primary.jar", "primary": true}
+			]
+		}]`, newVersionID)
+
+		httpmock.RegisterRegexpResponder("GET",
+			regexp.MustCompile(`^https://api\.modrinth\.com/v2/project/`+projectID+`/version`),
+			httpmock.NewStringResponder(200, body))
+
+		mod := newTestModrinthMod(t, "Test Mod", "old.jar", projectID, installedVersion)
+
+		results, err := mrUpdater{}.CheckUpdate([]*core.Mod{mod}, pack)
+		if err != nil {
+			t.Fatalf("CheckUpdate: %v", err)
+		}
+
+		if results[0].Error != nil {
+			t.Fatalf("unexpected per-mod error: %v", results[0].Error)
+		}
+
+		if !results[0].UpdateAvailable {
+			t.Fatalf("expected UpdateAvailable=true, got %+v", results[0])
+		}
+
+		// UpdateString prefers the primary file's filename, not the
+		// first file in the slice.
+		if results[0].UpdateString != "old.jar -> primary.jar" {
+			t.Errorf("UpdateString = %q, want %q",
+				results[0].UpdateString, "old.jar -> primary.jar")
+		}
+	})
+
+	t.Run("new version with no files yields per-mod error", func(t *testing.T) {
+		httpmock.Activate(t)
+		registerCleanup(t)
+
+		body := fmt.Sprintf(`[{
+			"id": %q,
+			"version_number": "2.0.0",
+			"game_versions": ["1.20.1"],
+			"loaders": ["fabric"],
+			"date_published": "2024-06-15T00:00:00Z",
+			"files": []
+		}]`, newVersionID)
+
+		httpmock.RegisterRegexpResponder("GET",
+			regexp.MustCompile(`^https://api\.modrinth\.com/v2/project/`+projectID+`/version`),
+			httpmock.NewStringResponder(200, body))
+
+		mod := newTestModrinthMod(t, "Test Mod", "old.jar", projectID, installedVersion)
+
+		results, err := mrUpdater{}.CheckUpdate([]*core.Mod{mod}, pack)
+		if err != nil {
+			t.Fatalf("CheckUpdate: %v", err)
+		}
+
+		if results[0].Error == nil {
+			t.Errorf("expected per-mod error for files-empty case, got %+v", results[0])
+		}
+	})
+
+	t.Run("getLatestVersion error becomes a per-mod error", func(t *testing.T) {
+		httpmock.Activate(t)
+		registerCleanup(t)
+
+		httpmock.RegisterRegexpResponder("GET",
+			regexp.MustCompile(`^https://api\.modrinth\.com/v2/project/`+projectID+`/version`),
+			httpmock.NewStringResponder(500, `{"error":"boom"}`))
+
+		mod := newTestModrinthMod(t, "Test Mod", "old.jar", projectID, installedVersion)
+
+		results, err := mrUpdater{}.CheckUpdate([]*core.Mod{mod}, pack)
+		if err != nil {
+			t.Fatalf("CheckUpdate returned overall error: %v", err)
+		}
+
+		if results[0].Error == nil {
+			t.Errorf("expected per-mod error from getLatestVersion 500, got %+v", results[0])
+		}
+	})
+}

--- a/utils/markdown_test.go
+++ b/utils/markdown_test.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestDisableTag(t *testing.T) {
+	t.Run("single leaf command", func(t *testing.T) {
+		c := &cobra.Command{Use: "root"}
+
+		disableTag(c)
+
+		if !c.DisableAutoGenTag {
+			t.Error("DisableAutoGenTag was not set on a leaf command")
+		}
+	})
+
+	t.Run("propagates to children and grandchildren", func(t *testing.T) {
+		root := &cobra.Command{Use: "root"}
+		child := &cobra.Command{Use: "child"}
+		grandchild := &cobra.Command{Use: "grandchild"}
+
+		root.AddCommand(child)
+		child.AddCommand(grandchild)
+
+		disableTag(root)
+
+		for _, c := range []*cobra.Command{root, child, grandchild} {
+			if !c.DisableAutoGenTag {
+				t.Errorf("DisableAutoGenTag was not set on command %q", c.Use)
+			}
+		}
+	})
+
+	t.Run("propagates across multiple siblings", func(t *testing.T) {
+		root := &cobra.Command{Use: "root"}
+		a := &cobra.Command{Use: "a"}
+		b := &cobra.Command{Use: "b"}
+		c := &cobra.Command{Use: "c"}
+
+		root.AddCommand(a, b, c)
+
+		disableTag(root)
+
+		for _, cmd := range []*cobra.Command{root, a, b, c} {
+			if !cmd.DisableAutoGenTag {
+				t.Errorf("DisableAutoGenTag was not set on command %q", cmd.Use)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds unit tests for the existing codebase. Currently ~40% overall coverage, with `curseforge/murmur2` at 100% and the other packages between 25% and 50%.

**Covered**: pure helpers throughout `core/`, TOML round-trips against the vendored `packwiz-example-pack@v1` fixture, the Modrinth and CurseForge API clients via `httpmock`, both `CheckUpdate` implementations, the GitHub backend's release-selection flow, and the `packinterop` accessors.

**Deferred (and why)**:
- Cobra `Run` bodies in `cmd/`, `settings/`, `url/`: they call `os.Exit` on errors. Cleanly testing them would mean refactoring those error paths to return errors instead.
- `core/download.go`'s `DownloadSession` + `CacheIndex` machinery: HTTP + filesystem + goroutines, architecturally entangled enough that I didn't want to attempt it in the same PR.
- `DoUpdate` methods on the three Updaters, and the install/import flows: heavy I/O paths better suited to a follow-up round with more fixture work.

While writing these tests I noticed that `LengthHasher.Sum(b)` (`core/hash.go`) and `Murmur2CF.Sum(b)` (`curseforge/murmur2/hash.go`) both violate the standard `hash.Hash` contract — they write the hash at offset 0 of `b` instead of appending to it. Latent today (all current callers pass `nil`), but I'd like to send a follow-up PR for the fix.

### Caveat

While I have decades of experience as a programmer, the only experience I have with Go was to hack something in place that was needed to make something work. These tests were written by AI (Claude) and I've reviewed them, but I'm not familiar with the specifics.

Feedback welcome on testing conventions, organization, missing cases, naming — anything.

## Test plan

- [ ] `go test ./...` passes locally (40 commits, all green)
- [ ] Maintainer review of testing patterns and conventions